### PR TITLE
API returns ALL FIELDS by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 target
 *.iml
 
-/src/test/java/com/kttdevelopment/mal4j/*.txt
+/src/test/java/resources/*.txt
 
 /docs/_site
 /docs/.jekyll-cache

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Mal4J is a standalone library and requires no additional dependencies.
 
 ## Contributing
 
-For devs running tests locally simply add a text file named `client.txt` that contains the client ID in the `src\test\java\com\kttdevelopment\mal4j` directory.
+For devs running tests locally simply add a text file named `client.txt` that contains the client ID in the `src/test/java/resources` directory.
+
+Please note that the Client ID being used for tests must not have a client secret and must have an app redirect url of `http://localhost:5050`.
 
 - Found a bug? Post it in [issues](https://github.com/Katsute/Mal4J/issues).
 - Have a suggestion or looking for inspiration? Check out our [discussions](https://github.com/Katsute/Mal4J/discussions).

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -2200,7 +2200,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final long getBirthday(){
+                public final Date getBirthday(){
+                    return new Date(birthday);
+                }
+
+                @Override
+                public final long getBirthdayEpochMillis(){
                     return birthday;
                 }
 

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -34,7 +34,6 @@ import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.time.Month;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.Function;
@@ -93,8 +92,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -113,8 +113,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
             }
@@ -133,7 +134,8 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getAnime(
                 auth,
                 id,
-                asStringList(fields))
+                asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS)
+            )
         ));
     }
 
@@ -149,8 +151,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         between(0, limit, 500),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -169,8 +172,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         between(0, limit, 500),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asAnimeRanking(MyAnimeListImpl.this, iterator)
                 );
             }
@@ -191,8 +195,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 500),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -213,8 +218,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 500),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
             }
@@ -233,8 +239,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -252,8 +259,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         between(0, limit, 100),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
             }
@@ -280,8 +288,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         between(0, priority.value(), 2),
                         between(0, timesRewatched, null),
                         between(0, rewatchValue.value(), 5),
-                        asStringList(tags),
-                        comments)
+                        toCommaSeparatedString(tags),
+                        comments
+                    )
                 );
                 if(response == null) return null;
 
@@ -296,7 +305,8 @@ final class MyAnimeListImpl extends MyAnimeList{
         handleVoidResponse(
             () -> service.deleteAnimeListing(
                 auth,
-                (int) id)
+                (int) id
+            )
         );
     }
 
@@ -319,7 +329,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         between(0, offset, null),
-                        asStringList(fields))
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS)
+                    )
                 );
                 if(response == null) return null;
 
@@ -340,7 +351,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         offset,
-                        asStringList(fields)),
+                        asFieldList(toCommaSeparatedString(fields), ALL_ANIME_FIELDS)
+                    ),
                     iterator -> asAnimeListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
                 );
             }
@@ -379,7 +391,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                 auth,
                 id,
                 limit == -1 ? null : between(0, limit, 100),
-                offset == -1 ? null : between(0, offset, null))
+                offset == -1 ? null : between(0, offset, null)
+            )
         );
         if(response == null) return null;
 
@@ -402,7 +415,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort,
                         query,
                         topicUsername,
-                        username)
+                        username
+                    )
                 );
                 if(response == null) return null;
 
@@ -425,7 +439,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort,
                         query,
                         topicUsername,
-                        username),
+                        username
+                    ),
                     iterator -> asForumTopicDetail(MyAnimeListImpl.this, iterator)
                 );
             }
@@ -445,8 +460,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -465,8 +481,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asManga(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
             }
@@ -486,7 +503,8 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getManga(
                 auth,
                 id,
-                asStringList(fields))
+                asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS)
+            )
         ));
     }
 
@@ -502,8 +520,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         between(0, limit, 500),
                         between(0, offset, null),
-                        asStringList(fields),
-                        nsfw)
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS),
+                        nsfw
+                    )
                 );
                 if(response == null) return null;
 
@@ -522,8 +541,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         between(0, limit, 500),
                         offset,
-                        asStringList(fields),
-                        nsfw),
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS),
+                        nsfw
+                    ),
                     iterator -> asMangaRanking(MyAnimeListImpl.this, iterator)
                 );
             }
@@ -551,8 +571,9 @@ final class MyAnimeListImpl extends MyAnimeList{
                         between(0, priority.value(), 2),
                         between(0, timesReread, null),
                         between(0, rereadValue.value(), 5),
-                        asStringList(tags),
-                        comments)
+                        toCommaSeparatedString(tags),
+                        comments
+                    )
                 );
                 if(response == null) return null;
 
@@ -567,7 +588,8 @@ final class MyAnimeListImpl extends MyAnimeList{
         handleVoidResponse(
             () -> service.deleteMangaListing(
                 auth,
-                id)
+                id
+            )
         );
     }
 
@@ -590,7 +612,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         between(0, offset, null),
-                        asStringList(fields))
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS)
+                    )
                 );
                 if(response == null) return null;
 
@@ -611,7 +634,8 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         offset,
-                        asStringList(fields)),
+                        asFieldList(toCommaSeparatedString(fields), ALL_MANGA_FIELDS)
+                    ),
                     iterator -> asMangaListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asMangaPreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
                 );
             }
@@ -625,7 +649,7 @@ final class MyAnimeListImpl extends MyAnimeList{
     }
 
     @Override
-    public final User getMyself(final String[] fields){
+    public final User getMyself(final String... fields){
         return getUser("@me", fields);
     }
 
@@ -644,7 +668,8 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getUser(
                 auth,
                 username.equals("@me") ? "@me" : URLEncoder.encode(username, StandardCharsets.UTF_8),
-                asStringList(fields))
+                asFieldList(toCommaSeparatedString(fields), ALL_USER_FIELDS)
+            )
         ));
     }
 
@@ -760,12 +785,27 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     //
 
-    private static String asStringList(final List<String> fields){
-        return asStringList(fields == null ? null : fields.toArray(new String[0]));
+    /**
+     * Handles how fields are finally sent to the server.
+     *
+     * Current behavior sends all if fields are null and none if an empty array is supplied
+     *
+     * @param fields comma separated fields
+     * @param fieldsIfNull fallback fields
+     * @return fields
+     */
+    private static String asFieldList(final String fields, final String fieldsIfNull){
+        return fields == null ? fieldsIfNull : fields;
     }
 
-    private static String asStringList(final String... fields){
-        if(fields != null && fields.length > 0){
+    private static String toCommaSeparatedString(final List<String> fields){
+        return toCommaSeparatedString(fields == null ? null : fields.toArray(new String[0]));
+    }
+
+    private static String toCommaSeparatedString(final String... fields){
+        if(fields != null){
+            if(fields.length == 0) return ""; // return blank for empty array
+
             final StringBuilder SB = new StringBuilder();
             for(final String field : fields)
                 if(!field.isBlank())

--- a/src/main/java/com/kttdevelopment/mal4j/query/FieldSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/mal4j/query/FieldSearchQuery.java
@@ -18,15 +18,18 @@
 
 package com.kttdevelopment.mal4j.query;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.kttdevelopment.mal4j.MyAnimeList;
+
+import java.util.*;
 
 /**
- * Represents a field query.
+ * Represents a field query. Returns all fields by default.
  *
  * @param <T> this
  * @param <R> completed request
  *
+ * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_ANIME_FIELDS
+ * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_MANGA_FIELDS
  * @since 1.0.0
  * @version 1.0.0
  * @author Ktt Development
@@ -44,10 +47,12 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      * @param field a field or comma separated fields that should be returned
      * @return query
      *
-     * @see #withFields(String...)
-     * @see #withFields(List)
      * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_ANIME_FIELDS
      * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_MANGA_FIELDS
+     * @see #withFields(String...)
+     * @see #withFields(List)
+     * @see #withAllFields()
+     * @see #withNoFields()
      * @since 1.0.0
      */
     public final T withField(final String field){
@@ -65,10 +70,12 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      *
      * @return query
      *
-     * @see #withField(String)
-     * @see #withFields(List)
      * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_ANIME_FIELDS
      * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_MANGA_FIELDS
+     * @see #withField(String)
+     * @see #withFields(List)
+     * @see #withAllFields()
+     * @see #withNoFields()
      * @since 1.0.0
      */
     public final T withFields(final String... fields){
@@ -90,8 +97,12 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      *
      * @return query
      *
+     * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_ANIME_FIELDS
+     * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_MANGA_FIELDS
      * @see #withField(String)
      * @see #withFields(String...)
+     * @see #withAllFields()
+     * @see #withNoFields()
      * @since 1.0.0
      */
     public final T withFields(final List<String> fields){
@@ -103,6 +114,41 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
             for(String field : fields)
                 withField(field);
         }
+        return (T) this;
+    }
+
+    /**
+     * Makes query return all possible fields.
+     *
+     * @return query
+     *
+     * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_ANIME_FIELDS
+     * @see com.kttdevelopment.mal4j.MyAnimeList#ALL_MANGA_FIELDS
+     * @see #withField(String)
+     * @see #withFields(String...)
+     * @see #withFields(List)
+     * @see #withNoFields()
+     * @since 1.0.0
+     */
+    public final T withAllFields(){
+        this.fields = null;
+        return (T) this;
+    }
+
+    /**
+     * Makes query return only default fields.
+     *
+     * @return query
+     *
+     * @see com.kttdevelopment.mal4j.MyAnimeList#NO_FIELDS
+     * @see #withField(String)
+     * @see #withFields(String...)
+     * @see #withFields(List)
+     * @see #withAllFields()
+     * @since 1.0.0
+     */
+    public final T withNoFields(){
+        this.fields = Arrays.asList(MyAnimeList.NO_FIELDS);
         return (T) this;
     }
 

--- a/src/main/java/com/kttdevelopment/mal4j/user/User.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/User.java
@@ -60,9 +60,20 @@ public abstract class User implements IDN {
      *
      * @return birthday
      *
+     * @see #getBirthdayEpochMillis()
      * @since 1.0.0
      */
-    public abstract long getBirthday();
+    public abstract Date getBirthday();
+
+    /**
+     * Returns the user's birthday as milliseconds since epoch.
+     *
+     * @return birthday
+     *
+     * @see #getBirthday()
+     * @since 1.0.0
+     */
+    public abstract long getBirthdayEpochMillis();
 
     /**
      * Returns the user's location.

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -17,7 +17,7 @@ public class TestAnime {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        anime = mal.getAnime(TestProvider.AltAnimeID, MyAnimeList.ALL_ANIME_FIELDS);
+        anime = mal.getAnime(TestProvider.AltAnimeID);
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -81,7 +81,6 @@ public class TestAnimeListStatus {
             mal.getUserAnimeListing()
                 .withStatus(AnimeStatus.Watching)
                 .withLimit(1000)
-                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
 
         AnimeListStatus status = null;
@@ -103,7 +102,6 @@ public class TestAnimeListStatus {
             mal.getUserAnimeListing("KatsuteDev")
                 .withStatus(AnimeStatus.Watching)
                 .withLimit(1000)
-                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
 
         AnimeListStatus status = null;
@@ -121,7 +119,7 @@ public class TestAnimeListStatus {
     @Test @Order(3)
     public void testGetFromAnime(){
         final AnimeListStatus status = mal
-            .getAnime(TestProvider.AnimeID, MyAnimeList.ALL_ANIME_FIELDS)
+            .getAnime(TestProvider.AnimeID)
             .getListStatus();
         testStatus(status);
     }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -22,7 +22,7 @@ public class TestAnimeListStatus {
 
     @AfterAll
     public static void cleanup(){
-        TestProvider.testRequireLiveUser();
+        TestProvider.testRequireClientID();
 
         mal.deleteAnimeListing(TestProvider.AnimeID);
         final AnimeListStatus status = mal.updateAnimeListing(TestProvider.AnimeID)

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeRank.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeRank.java
@@ -23,7 +23,6 @@ public class TestAnimeRank {
         final List<AnimeRanking> ranking =
             mal.getAnimeRanking(AnimeRankingType.Movie)
                 .withLimit(1)
-                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
         final AnimeRanking first = ranking.get(0);
         Assertions.assertEquals(1, first.getRanking());

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSearch.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSearch.java
@@ -20,6 +20,7 @@ public class TestAnimeSearch {
         final List<Anime> search =
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
+                .withAllFields()
                 .search();
         Assertions.assertEquals(TestProvider.AnimeID, search.get(0).getID());
         Assertions.assertNotEquals(1, search.size());
@@ -29,7 +30,7 @@ public class TestAnimeSearch {
     public void testOffsetLimit(){
         final List<Anime> search =
             mal.getAnime()
-                .withQuery(TestProvider.AnimeQuery)
+                .withQuery(TestProvider.AltAnimeQuery)
                 .withLimit(1)
                 .withOffset(1)
                 .search();
@@ -43,7 +44,7 @@ public class TestAnimeSearch {
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .withLimit(1)
-                .withFields(MyAnimeList.NO_FIELDS)
+                .withNoFields()
                 .search();
         Assertions.assertNull(search.get(0).getType());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSearch.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSearch.java
@@ -43,6 +43,7 @@ public class TestAnimeSearch {
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .withLimit(1)
+                .withFields(MyAnimeList.NO_FIELDS)
                 .search();
         Assertions.assertNull(search.get(0).getType());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSeason.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSeason.java
@@ -38,7 +38,6 @@ public class TestAnimeSeason {
             mal.getAnimeSeason(2020, Season.Winter)
                 .withLimit(2)
                 .sortBy(AnimeSeasonSort.Users)
-                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
         final AnimePreview first = season.get(0);
         final AnimePreview second = season.get(1);

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestUserAnimeListing.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestUserAnimeListing.java
@@ -23,7 +23,6 @@ public class TestUserAnimeListing {
         final List<AnimeListStatus> list =
             mal.getUserAnimeListing()
                .withStatus(AnimeStatus.Dropped)
-               .withField(MyAnimeList.ALL_ANIME_FIELDS)
                .search();
         Assertions.assertEquals(AnimeStatus.Dropped, list.get(0).getStatus());
     }
@@ -33,7 +32,6 @@ public class TestUserAnimeListing {
         final List<AnimeListStatus> list =
             mal.getUserAnimeListing()
                .sortBy(AnimeSort.UpdatedAt)
-               .withField(MyAnimeList.ALL_ANIME_FIELDS)
                .search();
         Assertions.assertTrue(list.get(0).getUpdatedAt().getTime() > list.get(1).getUpdatedAt().getTime());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -16,7 +16,7 @@ public class TestManga {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        manga = mal.getManga(TestProvider.MangaID, MyAnimeList.ALL_MANGA_FIELDS);
+        manga = mal.getManga(TestProvider.MangaID);
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -22,7 +22,7 @@ public class TestMangaListStatus {
 
     @AfterAll
     public static void cleanup(){
-        TestProvider.testRequireLiveUser();
+        TestProvider.testRequireClientID();
 
         mal.deleteMangaListing(TestProvider.MangaID);
         final MangaListStatus status = mal.updateMangaListing(TestProvider.MangaID)

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -83,7 +83,6 @@ public class TestMangaListStatus {
             mal.getUserMangaListing()
                 .withStatus(MangaStatus.Reading)
                 .withLimit(1000)
-                .withField(MyAnimeList.ALL_MANGA_FIELDS)
                 .search();
 
         MangaListStatus status = null;
@@ -98,13 +97,13 @@ public class TestMangaListStatus {
         testStatus(status);
     }
 
+    @SuppressWarnings("SpellCheckingInspection")
     @Test @Order(3) @DisplayName("testGetUsername(), #25 - Rereading status")
     public void testGetUsername(){
         final List<MangaListStatus> list =
             mal.getUserMangaListing("KatsuteDev")
                 .withStatus(MangaStatus.Reading)
                 .withLimit(1000)
-                .withField(MyAnimeList.ALL_MANGA_FIELDS)
                 .search();
 
         MangaListStatus status = null;
@@ -121,7 +120,7 @@ public class TestMangaListStatus {
 
     @Test @Order(3)
     public void testGetFromManga(){
-        final MangaListStatus status = mal.getManga(TestProvider.MangaID, MyAnimeList.ALL_MANGA_FIELDS).getListStatus();
+        final MangaListStatus status = mal.getManga(TestProvider.MangaID).getListStatus();
         testStatus(status);
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaRank.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaRank.java
@@ -23,7 +23,6 @@ public class TestMangaRank {
         final List<MangaRanking> ranking =
             mal.getMangaRanking(MangaRankingType.Manga)
                 .withLimit(1)
-                .withFields(MyAnimeList.ALL_MANGA_FIELDS)
                 .search();
         final MangaRanking first = ranking.get(0);
         Assertions.assertEquals(1,first.getRanking());

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaSearch.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaSearch.java
@@ -21,6 +21,7 @@ public class TestMangaSearch {
         final List<Manga> search =
             mal.getManga()
                 .withQuery(TestProvider.AltMangaQuery)
+                .withAllFields()
                 .search();
         Assertions.assertEquals(TestProvider.AltMangaID, search.get(0).getID());
         Assertions.assertNotEquals(1, search.size());
@@ -44,7 +45,7 @@ public class TestMangaSearch {
             mal.getManga()
                 .withQuery(TestProvider.MangaQuery)
                 .withLimit(1)
-                .withFields(MyAnimeList.NO_FIELDS)
+                .withNoFields()
                 .search();
         Assertions.assertNull(search.get(0).getType());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaSearch.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaSearch.java
@@ -44,7 +44,7 @@ public class TestMangaSearch {
             mal.getManga()
                 .withQuery(TestProvider.MangaQuery)
                 .withLimit(1)
-                .withFields(new String[0])
+                .withFields(MyAnimeList.NO_FIELDS)
                 .search();
         Assertions.assertNull(search.get(0).getType());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestUserMangaListing.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestUserMangaListing.java
@@ -24,7 +24,6 @@ public class TestUserMangaListing {
             mal.getUserMangaListing()
                .withStatus(MangaStatus.PlanToRead)
                .withLimit(1)
-               .withField(MyAnimeList.ALL_MANGA_FIELDS)
                .search();
         Assertions.assertEquals(MangaStatus.PlanToRead, list.get(0).getStatus());
     }
@@ -35,7 +34,6 @@ public class TestUserMangaListing {
             mal.getUserMangaListing()
                .sortBy(MangaSort.UpdatedAt)
                .withLimit(2)
-               .withField(MyAnimeList.ALL_MANGA_FIELDS)
                .search();
         Assertions.assertTrue(list.get(0).getUpdatedAt().getTime() > list.get(1).getUpdatedAt().getTime());
     }

--- a/src/test/java/com/kttdevelopment/mal4j/TestAuthRefresh.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestAuthRefresh.java
@@ -10,16 +10,18 @@ public class TestAuthRefresh {
 
     @BeforeAll
     public static void beforeAll() throws IOException{
-        TestProvider.testRequireLiveUser();
+        TestProvider.testRequireClientID();
 
         final String clientId = Files.readString(TestProvider.client);
         final MyAnimeListAuthenticator authenticator = new MyAnimeListAuthenticator(clientId, null, 5050);
         final MyAnimeList mal = MyAnimeList.withAuthorization(authenticator);
 
+        // test refresh token
         Assertions.assertNotNull(mal.getAnime().withQuery(TestProvider.AnimeQuery).search());
         mal.refreshOAuthToken();
         Assertions.assertNotNull(mal.getAnime().withQuery(TestProvider.AnimeQuery).search());
 
+        // write stable OAuth
         Files.write(TestProvider.oauth, authenticator.getAccessToken().getToken().getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestIterator.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestIterator.java
@@ -17,7 +17,7 @@ public class TestIterator {
         final PaginatedIterator<Anime> iterator = mal
             .getAnime()
             .withQuery(TestProvider.AnimeQuery)
-            .withFields(MyAnimeList.NO_FIELDS)
+            .withNoFields()
             .withLimit(100)
             .searchAll();
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -38,10 +38,8 @@ public abstract class TestProvider {
 
     //
 
-    @SuppressWarnings("SpellCheckingInspection")
-    static final Path client = new File("src/test/java/com/kttdevelopment/mal4j/client.txt").toPath();
-    @SuppressWarnings("SpellCheckingInspection")
-    static final Path oauth  = new File("src/test/java/com/kttdevelopment/mal4j/oauth.txt").toPath();
+    static final Path client = new File("src/test/java/resources/client.txt").toPath();
+    static final Path oauth  = new File("src/test/java/resources/oauth.txt").toPath();
 
     public static void init() throws IOException{
         APICall.debug = false;
@@ -50,12 +48,12 @@ public abstract class TestProvider {
             if(mal.getAnime(AnimeID, new String[0]) != null)
                 return;
         }
-        testRequireLiveUser();
+        testRequireClientID(); // prevent CI from executing tests
         TestAuthRefresh.beforeAll(); // refresh old token
     }
 
-    public static void testRequireLiveUser(){
-        Assumptions.assumeTrue(client.toFile().exists(), "Skipping tests (client id missing)");
+    public static void testRequireClientID(){
+        Assumptions.assumeTrue(client.toFile().exists(), "File with Client ID was missing, please create a file with the Client ID at: " + client.toFile().getAbsolutePath());
     }
 
     public static MyAnimeList getMyAnimeList(){

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -15,6 +15,7 @@ public abstract class TestProvider {
     public static final String AnimeQuery = "さくら荘のペットな彼女";
     public static final long AnimeID = 13759;
 
+     public static final String AltAnimeQuery = "ソードアートオンライン"; // for tests that require additional fields
     public static final long AltAnimeID = 11757; // for tests that require additional fields
 
     public static final String NSFW_AnimeQuery = "いただきっセーエキ";

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -15,7 +15,7 @@ public class TestUser {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        user = mal.getMyself(MyAnimeList.ALL_USER_FIELDS);
+        user = mal.getMyself();
     }
 
     @SuppressWarnings("SpellCheckingInspection")

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -62,7 +62,8 @@ public class TestUser {
 
     @Test // test does actually pass
     public void testBirthday(){
-        Assumptions.assumeFalse(user.getBirthday() == -1, "User might not specify a birthday");
+        Assumptions.assumeTrue(user.getBirthday().getTime() != -1, "User might not specify a birthday");
+        Assumptions.assumeTrue(user.getBirthdayEpochMillis() != -1, "User might not specify a birthday");
     }
 
 }


### PR DESCRIPTION
**Major Changes:**
- All fields now returned by default (null is treated as all)
- Two new methods for FieldQuery
  - `#withAllFields` - includes all fields (null)
  - `#withNoFields` - includes only default fields (uses static `NO_FIELDS`)
- ⚠client.txt / oauth.txt has been moved to `src/test/java/resources`
- Added method to get user birthday as a Date

**Minor Changes:**
- Test repairs
- Documentation reordering
- Renamed string list method to comma separated string
  - Additional fixes to make method compatible with null to all change
- Minior test provider changes