### PR TITLE
Replace primitives with objects

### DIFF
--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -63,32 +63,32 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final int getWatching() {
+                public final Integer getWatching() {
                     return watching;
                 }
 
                 @Override
-                public final int getCompleted() {
+                public final Integer getCompleted() {
                     return completed;
                 }
 
                 @Override
-                public final int getOnHold() {
+                public final Integer getOnHold() {
                     return onHold;
                 }
 
                 @Override
-                public final int getDropped() {
+                public final Integer getDropped() {
                     return dropped;
                 }
 
                 @Override
-                public final int getPlanToWatch() {
+                public final Integer getPlanToWatch() {
                     return planToWatch;
                 }
 
                 @Override
-                public final int getUserCount() {
+                public final Integer getUserCount() {
                     return userCount;
                 }
 
@@ -139,7 +139,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final int getYear() {
+                public final Integer getYear() {
                     return year;
                 }
 
@@ -167,7 +167,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -232,7 +232,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -253,21 +253,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getEndDate() {
-                    return new Date(endDate);
+                    return endDate == null ? null : new Date(endDate);
                 }
 
                 @Override
-                public final long getEndDateEpochMillis(){
+                public final Long getEndDateEpochMillis(){
                     return endDate;
                 }
 
@@ -277,27 +277,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final float getMeanRating() {
+                public final Float  getMeanRating() {
                     return meanRating;
                 }
 
                 @Override
-                public final int getRank() {
+                public final Integer getRank() {
                     return rank;
                 }
 
                 @Override
-                public final int getPopularity() {
+                public final Integer getPopularity() {
                     return popularity;
                 }
 
                 @Override
-                public final int getUserListingCount() {
+                public final Integer getUserListingCount() {
                     return usersListing;
                 }
 
                 @Override
-                public final int getUserScoringCount() {
+                public final Integer getUserScoringCount() {
                     return usersScoring;
                 }
 
@@ -313,21 +313,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getCreatedAt() {
-                    return new Date(createdAt);
+                    return createdAt == null ? null : new Date(createdAt);
                 }
 
                 @Override
-                public final long getCreatedAtEpochMillis(){
+                public final Long getCreatedAtEpochMillis(){
                     return createdAt;
                 }
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
@@ -347,7 +347,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getEpisodes() {
+                public final Integer getEpisodes() {
                     return episodes;
                 }
 
@@ -367,7 +367,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getAverageEpisodeLength() {
+                public final Integer getAverageEpisodeLength() {
                     return episodeLength;
                 }
 
@@ -447,27 +447,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getScore() {
+                public final Integer getScore() {
                     return score;
                 }
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getFinishDate() {
-                    return new Date(finishDate);
+                    return finishDate == null ? null : new Date(finishDate);
                 }
 
                 @Override
-                public final long getFinishDateEpochMillis(){
+                public final Long getFinishDateEpochMillis(){
                     return finishDate;
                 }
 
@@ -488,26 +488,26 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
                 @Override
-                public final int getWatchedEpisodes() {
+                public final Integer getWatchedEpisodes() {
                     return watchedEpisodes;
                 }
 
                 @Override
-                public final boolean isRewatching() {
+                public final Boolean isRewatching() {
                     return rewatching;
                 }
 
                 @Override
-                public final int getTimesRewatched() {
+                public final Integer getTimesRewatched() {
                     return timesRewatched;
                 }
 
@@ -566,27 +566,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getScore() {
+                public final Integer getScore() {
                     return score;
                 }
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getFinishDate() {
-                    return new Date(finishDate);
+                    return finishDate == null ? null : new Date(finishDate);
                 }
 
                 @Override
-                public final long getFinishDateEpochMillis(){
+                public final Long getFinishDateEpochMillis(){
                     return finishDate;
                 }
 
@@ -607,26 +607,26 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
                 @Override
-                public final int getWatchedEpisodes() {
+                public final Integer getWatchedEpisodes() {
                     return watchedEpisodes;
                 }
 
                 @Override
-                public final boolean isRewatching() {
+                public final Boolean isRewatching() {
                     return rewatching;
                 }
 
                 @Override
-                public final int getTimesRewatched() {
+                public final Integer getTimesRewatched() {
                     return timesRewatched;
                 }
 
@@ -696,7 +696,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -717,21 +717,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getEndDate() {
-                    return new Date(endDate);
+                    return endDate == null ? null : new Date(endDate);
                 }
 
                 @Override
-                public final long getEndDateEpochMillis(){
+                public final Long getEndDateEpochMillis(){
                     return endDate;
                 }
 
@@ -741,27 +741,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final float getMeanRating() {
+                public final Float  getMeanRating() {
                     return meanRating;
                 }
 
                 @Override
-                public final int getRank() {
+                public final Integer getRank() {
                     return rank;
                 }
 
                 @Override
-                public final int getPopularity() {
+                public final Integer getPopularity() {
                     return popularity;
                 }
 
                 @Override
-                public final int getUserListingCount() {
+                public final Integer getUserListingCount() {
                     return usersListing;
                 }
 
                 @Override
-                public final int getUserScoringCount() {
+                public final Integer getUserScoringCount() {
                     return usersScoring;
                 }
 
@@ -777,21 +777,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getCreatedAt() {
-                    return new Date(createdAt);
+                    return createdAt == null ? null : new Date(createdAt);
                 }
 
                 @Override
-                public final long getCreatedAtEpochMillis(){
+                public final Long getCreatedAtEpochMillis(){
                     return createdAt;
                 }
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
@@ -811,7 +811,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getEpisodes() {
+                public final Integer getEpisodes() {
                     return episodes;
                 }
 
@@ -831,7 +831,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getAverageEpisodeLength() {
+                public final Integer getAverageEpisodeLength() {
                     return episodeLength;
                 }
 
@@ -875,12 +875,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getRanking(){
+                public final Integer getRanking(){
                     return ranking;
                 }
 
                 @Override
-                public final int getPreviousRank(){
+                public final Integer getPreviousRank(){
                     return previousRanking;
                 }
 
@@ -912,7 +912,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getRecommendations() {
+                public final Integer getRecommendations() {
                     return recommendations;
                 }
 
@@ -984,7 +984,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1025,7 +1025,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // APi methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1035,7 +1035,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final long getCreatedAt() {
+                public final Long getCreatedAt() {
                     return createdAt;
                 }
 
@@ -1045,12 +1045,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getPostsCount() {
+                public final Integer getPostsCount() {
                     return posts;
                 }
 
                 @Override
-                public final long getLastPostCreatedAt() {
+                public final Long getLastPostCreatedAt() {
                     return lastPostedAt;
                 }
 
@@ -1060,7 +1060,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final boolean isLocked() {
+                public final Boolean isLocked() {
                     return locked;
                 }
 
@@ -1085,7 +1085,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1095,7 +1095,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final boolean isClosed() {
+                public final Boolean isClosed() {
                     return isClosed;
                 }
 
@@ -1129,8 +1129,8 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
-                    return 0;
+                public final Long getID() {
+                    return id;
                 }
 
                 @Override
@@ -1139,7 +1139,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getVotes() {
+                public final Integer getVotes() {
                     return votes;
                 }
 
@@ -1168,7 +1168,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1208,7 +1208,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1279,7 +1279,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1350,17 +1350,17 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
                 @Override
-                public final int getNumber() {
+                public final Integer getNumber() {
                     return number;
                 }
 
                 @Override
-                public final long getCreatedAt() {
+                public final Long getCreatedAt() {
                     return createdAt;
                 }
 
@@ -1409,7 +1409,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1448,7 +1448,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1513,7 +1513,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1534,21 +1534,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getEndDate() {
-                    return new Date(endDate);
+                    return endDate == null ? null : new Date(endDate);
                 }
 
                 @Override
-                public final long getEndDateEpochMillis(){
+                public final Long getEndDateEpochMillis(){
                     return endDate;
                 }
 
@@ -1558,27 +1558,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final float getMeanRating() {
+                public final Float  getMeanRating() {
                     return meanRating;
                 }
 
                 @Override
-                public final int getRank() {
+                public final Integer getRank() {
                     return rank;
                 }
 
                 @Override
-                public final int getPopularity() {
+                public final Integer getPopularity() {
                     return popularity;
                 }
 
                 @Override
-                public final int getUserListingCount() {
+                public final Integer getUserListingCount() {
                     return usersListing;
                 }
 
                 @Override
-                public final int getUserScoringCount() {
+                public final Integer getUserScoringCount() {
                     return usersScoring;
                 }
 
@@ -1594,21 +1594,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getCreatedAt() {
-                    return new Date(createdAt);
+                    return createdAt == null ? null : new Date(createdAt);
                 }
 
                 @Override
-                public final long getCreatedAtEpochMillis(){
+                public final Long getCreatedAtEpochMillis(){
                     return createdAt;
                 }
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
@@ -1628,12 +1628,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getVolumes() {
+                public final Integer getVolumes() {
                     return volumes;
                 }
 
                 @Override
-                public final int getChapters() {
+                public final Integer getChapters() {
                     return chapters;
                 }
 
@@ -1709,27 +1709,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getScore() {
+                public final Integer getScore() {
                     return score;
                 }
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getFinishDate() {
-                    return new Date(finishDate);
+                    return finishDate == null ? null : new Date(finishDate);
                 }
 
                 @Override
-                public final long getFinishDateEpochMillis(){
+                public final Long getFinishDateEpochMillis(){
                     return finishDate;
                 }
 
@@ -1750,31 +1750,31 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
                 @Override
-                public final int getVolumesRead() {
+                public final Integer getVolumesRead() {
                     return volumesRead;
                 }
 
                 @Override
-                public final int getChaptersRead() {
+                public final Integer getChaptersRead() {
                     return chaptersRead;
                 }
 
                 @Override
-                public final boolean isRereading() {
+                public final Boolean isRereading() {
                     return rereading;
                 }
 
                 @Override
-                public final int getTimesReread() {
+                public final Integer getTimesReread() {
                     return timesReread;
                 }
 
@@ -1833,27 +1833,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getScore() {
+                public final Integer getScore() {
                     return score;
                 }
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getFinishDate() {
-                    return new Date(finishDate);
+                    return finishDate == null ? null : new Date(finishDate);
                 }
 
                 @Override
-                public final long getFinishDateEpochMillis(){
+                public final Long getFinishDateEpochMillis(){
                     return finishDate;
                 }
 
@@ -1874,31 +1874,31 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
                 @Override
-                public final int getVolumesRead() {
+                public final Integer getVolumesRead() {
                     return volumesRead;
                 }
 
                 @Override
-                public final int getChaptersRead() {
+                public final Integer getChaptersRead() {
                     return chaptersRead;
                 }
 
                 @Override
-                public final boolean isRereading() {
+                public final Boolean isRereading() {
                     return rereading;
                 }
 
                 @Override
-                public final int getTimesReread() {
+                public final Integer getTimesReread() {
                     return timesReread;
                 }
 
@@ -1964,7 +1964,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID() {
+                public final Long getID() {
                     return id;
                 }
 
@@ -1985,21 +1985,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getStartDate() {
-                    return new Date(startDate);
+                    return startDate == null ? null : new Date(startDate);
                 }
 
                 @Override
-                public final long getStartDateEpochMillis(){
+                public final Long getStartDateEpochMillis(){
                     return startDate;
                 }
 
                 @Override
                 public final Date getEndDate() {
-                    return new Date(endDate);
+                    return endDate == null ? null : new Date(endDate);
                 }
 
                 @Override
-                public final long getEndDateEpochMillis(){
+                public final Long getEndDateEpochMillis(){
                     return endDate;
                 }
 
@@ -2009,27 +2009,27 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final float getMeanRating() {
+                public final Float  getMeanRating() {
                     return meanRating;
                 }
 
                 @Override
-                public final int getRank() {
+                public final Integer getRank() {
                     return rank;
                 }
 
                 @Override
-                public final int getPopularity() {
+                public final Integer getPopularity() {
                     return popularity;
                 }
 
                 @Override
-                public final int getUserListingCount() {
+                public final Integer getUserListingCount() {
                     return usersListing;
                 }
 
                 @Override
-                public final int getUserScoringCount() {
+                public final Integer getUserScoringCount() {
                     return usersScoring;
                 }
 
@@ -2045,21 +2045,21 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getCreatedAt() {
-                    return new Date(createdAt);
+                    return createdAt == null ? null : new Date(createdAt);
                 }
 
                 @Override
-                public final long getCreatedAtEpochMillis(){
+                public final Long getCreatedAtEpochMillis(){
                     return createdAt;
                 }
 
                 @Override
                 public final Date getUpdatedAt() {
-                    return new Date(updatedAt);
+                    return updatedAt == null ? null : new Date(updatedAt);
                 }
 
                 @Override
-                public final long getUpdatedAtEpochMillis(){
+                public final Long getUpdatedAtEpochMillis(){
                     return updatedAt;
                 }
 
@@ -2079,12 +2079,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getVolumes() {
+                public final Integer getVolumes() {
                     return volumes;
                 }
 
                 @Override
-                public final int getChapters() {
+                public final Integer getChapters() {
                     return chapters;
                 }
 
@@ -2123,12 +2123,12 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getRanking() {
+                public final Integer getRanking() {
                     return ranking;
                 }
 
                 @Override
-                public final int getPreviousRank() {
+                public final Integer getPreviousRank() {
                     return previousRanking;
                 }
 
@@ -2161,7 +2161,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final int getRecommendations() {
+                public final Integer getRecommendations() {
                     return recommendations;
                 }
 
@@ -2241,7 +2241,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final long getID(){
+                public final Long getID(){
                     return id;
                 }
 
@@ -2262,11 +2262,11 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getBirthday(){
-                    return new Date(birthday);
+                    return birthday == null ? null : new Date(birthday);
                 }
 
                 @Override
-                public final long getBirthdayEpochMillis(){
+                public final Long getBirthdayEpochMillis(){
                     return birthday;
                 }
 
@@ -2277,11 +2277,11 @@ abstract class MyAnimeListAPIResponseMapping {
 
                 @Override
                 public final Date getJoinedAt(){
-                    return new Date(joinedAt);
+                    return joinedAt == null ? null : new Date(joinedAt);
                 }
 
                 @Override
-                public final long getJoinedAtEpochMillis(){
+                public final Long getJoinedAtEpochMillis(){
                     return joinedAt;
                 }
 
@@ -2296,7 +2296,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 @Override
-                public final boolean isSupporter(){
+                public final Boolean isSupporter(){
                     return supporter;
                 }
 
@@ -2332,78 +2332,78 @@ abstract class MyAnimeListAPIResponseMapping {
                 // API methods
 
                 @Override
-                public final int getItemsWatching(){
+                public final Integer getItemsWatching(){
                     return watching;
                 }
 
                 @Override
-                public final int getItemsCompleted(){
+                public final Integer getItemsCompleted(){
                     return completed;
                 }
 
                 @Override
-                public final int getItemsOnHold(){
+                public final Integer getItemsOnHold(){
                     return onHold;
                 }
 
                 @Override
-                public final int getItemsDropped(){
+                public final Integer getItemsDropped(){
                     return dropped;
                 }
 
                 @Override
-                public final int getItemsPlanToWatch(){
+                public final Integer getItemsPlanToWatch(){
                     return planToWatch;
                 }
 
                 @Override
-                public final int getItems(){
+                public final Integer getItems(){
                     return items;
                 }
 
                 @Override
-                public final float getDaysWatched(){
+                public final Float  getDaysWatched(){
                     return days;
                 }
 
                 @Override
-                public final float getDaysWatching(){
+                public final Float  getDaysWatching(){
                     return daysWatching;
                 }
 
                 @Override
-                public final float getDaysCompleted(){
+                public final Float  getDaysCompleted(){
                     return daysCompleted;
                 }
 
                 @Override
-                public final float getDaysOnHold(){
+                public final Float  getDaysOnHold(){
                     return daysOnHold;
                 }
 
                 @Override
-                public final float getDaysDropped(){
+                public final Float  getDaysDropped(){
                     return daysDropped;
                 }
 
                 @Override
-                public final float getDays(){
+                public final Float  getDays(){
                     return days;
                 }
 
                 @Override
-                public final int getEpisodes(){
+                public final Integer getEpisodes(){
                     return episodesWatched;
                 }
 
                 @SuppressWarnings("SpellCheckingInspection")
                 @Override
-                public final int getTimesRewatched(){
+                public final Integer getTimesRewatched(){
                     return timesRewatched;
                 }
 
                 @Override
-                public final float getMeanScore(){
+                public final Float  getMeanScore(){
                     return meanScore;
                 }
 
@@ -2545,27 +2545,27 @@ abstract class MyAnimeListAPIResponseMapping {
             private final Integer minute    = m;
 
             @Override
-            public final int getHour() {
+            public final Integer getHour() {
                 return hour;
             }
 
             @Override
-            public final int get12Hour() {
+            public final Integer get12Hour() {
                 return hour12;
             }
 
             @Override
-            public final boolean isAM() {
+            public final Boolean isAM() {
                 return am;
             }
 
             @Override
-            public final boolean isPM() {
+            public final Boolean isPM() {
                 return !am;
             }
 
             @Override
-            public final int getMinute() {
+            public final Integer getMinute() {
                 return minute;
             }
 

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -53,12 +53,12 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimeStatistics asAnimeStatistics(final MyAnimeList mal, final JsonObject schema){
             return new AnimeStatistics() {
 
-                private final int   watching    = requireNonNullElse(() -> schema.getJsonObject("status").getInt("watching"), 0),
-                                    completed   = requireNonNullElse(() -> schema.getJsonObject("status").getInt("completed"), 0),
-                                    onHold      = requireNonNullElse(() -> schema.getJsonObject("status").getInt("on_hold"), 0),
-                                    dropped     = requireNonNullElse(() -> schema.getJsonObject("status").getInt("dropped"), 0),
-                                    planToWatch = requireNonNullElse(() -> schema.getJsonObject("status").getInt("plan_to_watch"), 0),
-                                    userCount   = requireNonNullElse(() -> schema.getInt("num_list_users"), -1);
+                private final Integer   watching    = requireNonNull(() -> schema.getJsonObject("status").getInt("watching")),
+                                        completed   = requireNonNull(() -> schema.getJsonObject("status").getInt("completed")),
+                                        onHold      = requireNonNull(() -> schema.getJsonObject("status").getInt("on_hold")),
+                                        dropped     = requireNonNull(() -> schema.getJsonObject("status").getInt("dropped")),
+                                        planToWatch = requireNonNull(() -> schema.getJsonObject("status").getInt("plan_to_watch")),
+                                        userCount   = requireNonNull(() -> schema.getInt("num_list_users"));
 
                 // API methods
 
@@ -133,7 +133,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static StartSeason asStartSeason(final MyAnimeList mal, final JsonObject schema){
             return new StartSeason() {
 
-                private final int year      = requireNonNullElse(() -> schema.getInt("year"), -1);
+                private final Integer year  = requireNonNull(() -> schema.getInt("year"));
                 private final Season season = requireNonNull(() -> Season.asEnum(schema.getString("season")));
 
                 // API methods
@@ -161,7 +161,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static Studio asStudio(final MyAnimeList mal, final JsonObject schema){
             return new Studio() {
 
-                private final long id       = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
                 private final String name   = requireNonNull(() -> schema.getString("name"));
 
                 // API methods
@@ -189,38 +189,45 @@ abstract class MyAnimeListAPIResponseMapping {
         static com.kttdevelopment.mal4j.anime.Anime asAnime(final MyAnimeList mal, final JsonObject schema){
             return new com.kttdevelopment.mal4j.anime.Anime() {
 
-                private final long id               = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
                 private final String title          = requireNonNull(() -> schema.getString("title"));
                 private final Picture mainPicture   = requireNonNull(() -> Common.asPicture(mal, schema.getJsonObject("main_picture")));
-                private final AlternativeTitles alternativeTitles = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long endDate          = requireNonNullElse(() -> parseDate(schema.getString("end_date")), -1L);
+                private final AlternativeTitles alternativeTitles
+                                                    = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
+                private final Long startDate        = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long endDate          = requireNonNull(() -> parseDate(schema.getString("end_date")));
                 private final String synopsis       = requireNonNull(() -> schema.getString("synopsis"));
-                private final float meanRating      = requireNonNullElse(() -> schema.getFloat("mean"), 0f);
-                private final int rank              = requireNonNullElse(() -> schema.getInt("rank"), -1);
-                private final int popularity        = requireNonNullElse(() -> schema.getInt("popularity"), -1);
-                private final int usersListing      = requireNonNullElse(() -> schema.getInt("num_list_users"), -1);
-                private final int usersScoring      = requireNonNullElse(() -> schema.getInt("num_scoring_users"), -1);
+                private final Float meanRating      = requireNonNull(() -> schema.getFloat("mean"));
+                private final Integer rank          = requireNonNull(() -> schema.getInt("rank"));
+                private final Integer popularity    = requireNonNull(() -> schema.getInt("popularity"));
+                private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
+                private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
                 private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
-                private final long createdAt        = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
+                private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
+                private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final AnimeType type        = requireNonNull(() -> AnimeType.asEnum(schema.getString("media_type")));
                 private final AnimeAirStatus status = requireNonNull(() -> AnimeAirStatus.asEnum(schema.getString("status")));
-                private final AnimeListStatus listStatus = requireNonNull(() -> asAnimeListStatus(mal, schema.getJsonObject("my_list_status"), this));
-                private final int episodes          = requireNonNullElse(() -> schema.getInt("num_episodes"), -1);
-                private final StartSeason startSeason = requireNonNull(() -> asStartSeason(mal, schema.getJsonObject("start_season")));
+                private final AnimeListStatus listStatus
+                                                    = requireNonNull(() -> asAnimeListStatus(mal, schema.getJsonObject("my_list_status"), this));
+                private final Integer episodes      = requireNonNull(() -> schema.getInt("num_episodes"));
+                private final StartSeason startSeason
+                                                    = requireNonNull(() -> asStartSeason(mal, schema.getJsonObject("start_season")));
                 private final Broadcast broadcast   = requireNonNull(() -> asBroadcast(mal, schema.getJsonObject("broadcast")));
                 private final AnimeSource source    = requireNonNull(() -> AnimeSource.asEnum(schema.getString("source")));
-                private final int episodeLength     = requireNonNullElse(() -> schema.getInt("average_episode_duration"), -1);
+                private final Integer episodeLength = requireNonNull(() -> schema.getInt("average_episode_duration"));
                 private final AnimeRating rating    = requireNonNull(() -> AnimeRating.asEnum(schema.getString("rating")));
                 private final Studio[] studios      = requireNonNull(() -> adaptList(schema.getJsonArray("studios"), s -> asStudio(mal, s), Studio.class));
                 private final Picture[] pictures    = requireNonNull(() -> adaptList(schema.getJsonArray("pictures"), p -> Common.asPicture(mal, p), Picture.class));
                 private final String background     = requireNonNull(() -> schema.getString("background"));
-                private final RelatedAnime[] relatedAnime = requireNonNull(() -> adaptList(schema.getJsonArray("related_anime"), a -> asRelatedAnime(mal, a), RelatedAnime.class));
-                private final RelatedManga[] relatedManga = requireNonNull(() -> adaptList(schema.getJsonArray("related_manga"), m -> Manga.asRelatedManga(mal, m), RelatedManga.class));
-                private final AnimeRecommendation[] recommendations = requireNonNull(() -> adaptList(schema.getJsonArray("recommendations"), r -> asAnimeRecommendation(mal, r), AnimeRecommendation.class));
-                private final AnimeStatistics statistics = requireNonNull(() -> asAnimeStatistics(mal, schema.getJsonObject("statistics")));
+                private final RelatedAnime[] relatedAnime
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("related_anime"), a -> asRelatedAnime(mal, a), RelatedAnime.class));
+                private final RelatedManga[] relatedManga
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("related_manga"), m -> Manga.asRelatedManga(mal, m), RelatedManga.class));
+                private final AnimeRecommendation[] recommendations
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("recommendations"), r -> asAnimeRecommendation(mal, r), AnimeRecommendation.class));
+                private final AnimeStatistics statistics
+                                                    = requireNonNull(() -> asAnimeStatistics(mal, schema.getJsonObject("statistics")));
 
                 // API methods
 
@@ -418,18 +425,18 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimeListStatus asAnimeListStatus(final MyAnimeList mal, final JsonObject schema, final long anime_id) {
             return new AnimeListStatus() {
 
-                private final long id               = requireNonNullElse(() -> anime_id, -1L);
-                private final AnimeStatus status    = requireNonNull(() -> AnimeStatus.asEnum(schema.getString("status")));
-                private final int score             = requireNonNullElse(() -> schema.getInt("score"), -1);
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long finishDate       = requireNonNullElse(() -> parseDate(schema.getString("finish_date")), -1L);
-                private final Priority priority     = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
-                private final String[] tags         = requireNonNull(() -> schema.getStringArray("tags"));
-                private final String comments       = requireNonNull(() -> schema.getString("comments"));
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
-                private final int watchedEpisodes   = requireNonNullElse(() -> schema.getInt("num_episodes_watched"), -1);
-                private final boolean rewatching    = requireNonNullElse(() -> (boolean) schema.get("is_rewatching"), false);
-                private final int timesRewatched    = requireNonNullElse(() -> schema.getInt("num_times_rewatched"), -1);
+                private final Long id                   = requireNonNull(() -> anime_id);
+                private final AnimeStatus status        = requireNonNull(() -> AnimeStatus.asEnum(schema.getString("status")));
+                private final Integer score             = requireNonNull(() -> schema.getInt("score"));
+                private final Long startDate            = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long finishDate           = requireNonNull(() -> parseDate(schema.getString("finish_date")));
+                private final Priority priority         = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
+                private final String[] tags             = requireNonNull(() -> schema.getStringArray("tags"));
+                private final String comments           = requireNonNull(() -> schema.getString("comments"));
+                private final Long updatedAt            = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
+                private final Integer watchedEpisodes   = requireNonNull(() -> schema.getInt("num_episodes_watched"));
+                private final Boolean rewatching        = requireNonNull(() -> schema.getBoolean("is_rewatching"));
+                private final Integer timesRewatched    = requireNonNull(() -> schema.getInt("num_times_rewatched"));
                 private final RewatchValue rewatchValue = requireNonNull(() -> RewatchValue.asEnum(schema.getInt("rewatch_value")));
 
                 // API methods
@@ -538,17 +545,17 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimeListStatus asAnimeListStatus(final MyAnimeList mal, final JsonObject schema, final AnimePreview anime) {
             return new AnimeListStatus() {
 
-                private final AnimeStatus status    = requireNonNull(() -> AnimeStatus.asEnum(schema.getString("status")));
-                private final int score             = requireNonNullElse(() -> schema.getInt("score"), -1);
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long finishDate       = requireNonNullElse(() -> parseDate(schema.getString("finish_date")), -1L);
-                private final Priority priority     = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
-                private final String[] tags         = requireNonNull(() -> schema.getStringArray("tags"));
-                private final String comments       = requireNonNull(() -> schema.getString("comments"));
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
-                private final int watchedEpisodes   = requireNonNullElse(() -> schema.getInt("num_episodes_watched"), -1);
-                private final boolean rewatching    = requireNonNullElse(() -> (boolean) schema.get("is_rewatching"), false);
-                private final int timesRewatched    = requireNonNullElse(() -> schema.getInt("num_times_rewatched"), -1);
+                private final AnimeStatus status        = requireNonNull(() -> AnimeStatus.asEnum(schema.getString("status")));
+                private final Integer score             = requireNonNull(() -> schema.getInt("score"));
+                private final Long startDate            = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long finishDate           = requireNonNull(() -> parseDate(schema.getString("finish_date")));
+                private final Priority priority         = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
+                private final String[] tags             = requireNonNull(() -> schema.getStringArray("tags"));
+                private final String comments           = requireNonNull(() -> schema.getString("comments"));
+                private final Long updatedAt            = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
+                private final Integer watchedEpisodes   = requireNonNull(() -> schema.getInt("num_episodes_watched"));
+                private final Boolean rewatching        = requireNonNull(() -> schema.getBoolean("is_rewatching"));
+                private final Integer timesRewatched    = requireNonNull(() -> schema.getInt("num_times_rewatched"));
                 private final RewatchValue rewatchValue = requireNonNull(() -> RewatchValue.asEnum(schema.getInt("rewatch_value")));
 
                 // API methods
@@ -656,30 +663,33 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimePreview asAnimePreview(final MyAnimeList mal, final JsonObject schema){
             return new AnimePreview() {
 
-                private final long id               = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
                 private final String title          = requireNonNull(() -> schema.getString("title"));
                 private final Picture mainPicture   = requireNonNull(() -> Common.asPicture(mal, schema.getJsonObject("main_picture")));
-                private final AlternativeTitles alternativeTitles = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long endDate          = requireNonNullElse(() -> parseDate(schema.getString("end_date")), -1L);
+                private final AlternativeTitles alternativeTitles
+                                                    = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
+                private final Long startDate        = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long endDate          = requireNonNull(() -> parseDate(schema.getString("end_date")));
                 private final String synopsis       = requireNonNull(() -> schema.getString("synopsis"));
-                private final float meanRating      = requireNonNullElse(() -> schema.getFloat("mean"), 0f);
-                private final int rank              = requireNonNullElse(() -> schema.getInt("rank"), -1);
-                private final int popularity        = requireNonNullElse(() -> schema.getInt("popularity"), -1);
-                private final int usersListing      = requireNonNullElse(() -> schema.getInt("num_list_users"), -1);
-                private final int usersScoring      = requireNonNullElse(() -> schema.getInt("num_scoring_users"), -1);
+                private final Float meanRating      = requireNonNull(() -> schema.getFloat("mean"));
+                private final Integer rank          = requireNonNull(() -> schema.getInt("rank"));
+                private final Integer popularity    = requireNonNull(() -> schema.getInt("popularity"));
+                private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
+                private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
                 private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
-                private final long createdAt        = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
+                private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
+                private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final AnimeType type        = requireNonNull(() -> AnimeType.asEnum(schema.getString("media_type")));
                 private final AnimeAirStatus status = requireNonNull(() -> AnimeAirStatus.asEnum(schema.getString("status")));
-                private final AnimeListStatus listStatus = requireNonNull(() -> asAnimeListStatus(mal, schema.getJsonObject("my_list_status"), this));
-                private final int episodes          = requireNonNullElse(() -> schema.getInt("num_episodes"), -1);
-                private final StartSeason startSeason = requireNonNull(() -> asStartSeason(mal, schema.getJsonObject("start_season")));
+                private final AnimeListStatus listStatus
+                                                    = requireNonNull(() -> asAnimeListStatus(mal, schema.getJsonObject("my_list_status"), this));
+                private final Integer episodes      = requireNonNull(() -> schema.getInt("num_episodes"));
+                private final StartSeason startSeason
+                                                    = requireNonNull(() -> asStartSeason(mal, schema.getJsonObject("start_season")));
                 private final Broadcast broadcast   = requireNonNull(() -> asBroadcast(mal, schema.getJsonObject("broadcast")));
                 private final AnimeSource source    = requireNonNull(() -> AnimeSource.asEnum(schema.getString("source")));
-                private final int episodeLength     = requireNonNullElse(() -> schema.getInt("average_episode_duration"), -1);
+                private final Integer episodeLength = requireNonNull(() -> schema.getInt("average_episode_duration"));
                 private final AnimeRating rating    = requireNonNull(() -> AnimeRating.asEnum(schema.getString("rating")));
                 private final Studio[] studios      = requireNonNull(() -> adaptList(schema.getJsonArray("studios"), s -> asStudio(mal, s), Studio.class));
 
@@ -853,9 +863,9 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimeRanking asAnimeRanking(final MyAnimeList mal, final JsonObject schema){
             return new AnimeRanking() {
 
-                private final AnimePreview anime    = requireNonNull(() -> asAnimePreview(mal, schema.getJsonObject("node")));
-                private final int ranking           = requireNonNullElse(() -> schema.getJsonObject("ranking").getInt("rank"), -1);
-                private final int previousRanking   = requireNonNullElse(() -> schema.getJsonObject("ranking").getInt("previous_rank"), -1);
+                private final AnimePreview anime        = requireNonNull(() -> asAnimePreview(mal, schema.getJsonObject("node")));
+                private final Integer ranking           = requireNonNull(() -> schema.getJsonObject("ranking").getInt("rank"));
+                private final Integer previousRanking   = requireNonNull(() -> schema.getJsonObject("ranking").getInt("previous_rank"));
 
                 // API methods
 
@@ -891,8 +901,8 @@ abstract class MyAnimeListAPIResponseMapping {
         static AnimeRecommendation asAnimeRecommendation(final MyAnimeList mal, final JsonObject schema){
             return new AnimeRecommendation() {
 
-                private final AnimePreview anime    = requireNonNull(() -> asAnimePreview(mal, schema.getJsonObject("node")));
-                private final int recommendations   = requireNonNullElse(() -> schema.getInt("num_recommendations"), -1);
+                private final AnimePreview anime        = requireNonNull(() -> asAnimePreview(mal, schema.getJsonObject("node")));
+                private final Integer recommendations   = requireNonNull(() -> schema.getInt("num_recommendations"));
 
                 // API methods
 
@@ -968,8 +978,8 @@ abstract class MyAnimeListAPIResponseMapping {
         static ForumTopicCreator asForumTopicCreator(final MyAnimeList mal, final JsonObject schema){
             return new ForumTopicCreator() {
 
-                private final long id = requireNonNullElse(() -> schema.getLong("id"), -1L);
-                private final String name = requireNonNull(() -> schema.getString("name"));
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
+                private final String name   = requireNonNull(() -> schema.getString("name"));
 
                 // API methods
 
@@ -1002,14 +1012,15 @@ abstract class MyAnimeListAPIResponseMapping {
         static ForumTopicDetail asForumTopicDetail(final MyAnimeList mal, final JsonObject schema){
             return new ForumTopicDetail() {
 
-                private final long id                       = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id                       = requireNonNull(() -> schema.getLong("id"));
                 private final String title                  = requireNonNull(() -> schema.getString("title"));
-                private final long createdAt                = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
+                private final Long createdAt                = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final ForumTopicCreator createdBy   = requireNonNull(() -> asForumTopicCreator(mal, schema.getJsonObject("created_by")));
-                private final int posts                     = requireNonNullElse(() -> schema.getInt("number_of_posts"), -1);
-                private final long lastPostedAt             = requireNonNullElse(() -> parseISO8601(schema.getString("last_post_created_at")), -1L);
-                private final ForumTopicCreator lastPostedBy = requireNonNull(() -> asForumTopicCreator(mal, schema.getJsonObject("last_post_created_by")));
-                private final boolean locked                = requireNonNullElse(() -> (boolean) schema.get("is_locked"), false);
+                private final Integer posts                 = requireNonNull(() -> schema.getInt("number_of_posts"));
+                private final Long lastPostedAt             = requireNonNull(() -> parseISO8601(schema.getString("last_post_created_at")));
+                private final ForumTopicCreator lastPostedBy
+                                                            = requireNonNull(() -> asForumTopicCreator(mal, schema.getJsonObject("last_post_created_by")));
+                private final Boolean locked                = requireNonNull(() -> schema.getBoolean("is_locked"));
 
                 // APi methods
 
@@ -1066,10 +1077,10 @@ abstract class MyAnimeListAPIResponseMapping {
         static Poll asPoll(final MyAnimeList mal, final JsonObject schema, final ForumTopic forumTopic){
             return new Poll() {
 
-                private final long id = requireNonNullElse(() -> schema.getLong("id"), -1L);
-                private final String question = requireNonNull(() -> schema.getString("question"));
-                private final boolean isClosed = requireNonNullElse(() -> (boolean) schema.get("close"), false);
-                private final PollOption[] options = requireNonNull(() -> adaptList(schema.getJsonArray("options"), o -> asPollOption(mal, o, this), PollOption.class));
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
+                private final String question       = requireNonNull(() -> schema.getString("question"));
+                private final Boolean isClosed      = requireNonNull(() -> schema.getBoolean("closed"));
+                private final PollOption[] options  = requireNonNull(() -> adaptList(schema.getJsonArray("options"), o -> asPollOption(mal, o, this), PollOption.class));
 
                 // API methods
 
@@ -1111,9 +1122,9 @@ abstract class MyAnimeListAPIResponseMapping {
         static PollOption asPollOption(final MyAnimeList mal, final JsonObject schema, final Poll poll){
             return new PollOption() {
 
-                private final long id       = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
                 private final String text   = requireNonNull(() -> schema.getString("text"));
-                private final int votes     = requireNonNullElse(() -> schema.getInt("votes"), -1);
+                private final Integer votes = requireNonNull(() -> schema.getInt("votes"));
 
                 // API methods
 
@@ -1150,7 +1161,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static PostAuthor asPostAuthor(final MyAnimeList mal, final JsonObject schema){
             return new PostAuthor() {
 
-                private final long id               = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
                 private final String name           = requireNonNull(() -> schema.getString("name"));
                 private final String forumAvatarURL = requireNonNull(() -> schema.getString("forum_avator"));
 
@@ -1189,7 +1200,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static ForumBoard asForumBoard(final MyAnimeList mal, final JsonObject schema, final ForumCategory forumCategory){
             return new ForumBoard() {
 
-                private final long id                   = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id                   = requireNonNull(() -> schema.getLong("id"));
                 private final String title              = requireNonNull(() -> schema.getString("title"));
                 private final String description        = requireNonNull(() -> schema.getString("description"));
                 private final ForumSubBoard[] subBoards = adaptList(schema.getJsonArray("subboards"), b -> asForumSubBoard(mal, b, this), ForumSubBoard.class);
@@ -1262,7 +1273,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static ForumSubBoard asForumSubBoard(final MyAnimeList mal, final JsonObject schema, final ForumBoard forumBoard){
             return new ForumSubBoard() {
 
-                private final long id       = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
                 private final String title  = requireNonNull(() -> schema.getString("title"));
 
                 // API methods
@@ -1295,9 +1306,9 @@ abstract class MyAnimeListAPIResponseMapping {
         static ForumTopic asForumTopic(final MyAnimeList mal, final JsonObject schema){
             return new ForumTopic() {
 
-                private final String title = requireNonNull(() -> schema.getString("title"));
-                private final Post[] posts = requireNonNull(() -> adaptList(schema.getJsonArray("posts"), p -> asPost(mal, p, this), Post.class));
-                private final Poll poll = requireNonNull(() -> asPoll(mal, schema.getJsonObject("poll"), this));
+                private final String title  = requireNonNull(() -> schema.getString("title"));
+                private final Post[] posts  = requireNonNull(() -> adaptList(schema.getJsonArray("posts"), p -> asPost(mal, p, this), Post.class));
+                private final Poll poll     = requireNonNull(() -> asPoll(mal, schema.getJsonObject("poll"), this));
 
                 // API methods
 
@@ -1329,9 +1340,9 @@ abstract class MyAnimeListAPIResponseMapping {
         static Post asPost(final MyAnimeList mal, final JsonObject schema, final ForumTopic forumTopic){
             return new Post() {
 
-                private final long id           = requireNonNullElse(() -> schema.getLong("id"), -1L);
-                private final int number        = requireNonNullElse(() -> schema.getInt("number"), -1);
-                private final long createdAt    = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
+                private final Long id           = requireNonNull(() -> schema.getLong("id"));
+                private final Integer number    = requireNonNull(() -> schema.getInt("number"));
+                private final Long createdAt    = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final PostAuthor author = requireNonNull(() -> asPostAuthor(mal, schema.getJsonObject("created_by")));
                 private final String body       = requireNonNull(() -> schema.getString("body"));
                 private final String signature  = requireNonNull(() -> schema.getString("signature"));
@@ -1390,7 +1401,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static Author asAuthor(final MyAnimeList mal, final JsonObject schema){
             return new Author() {
 
-                private final long id           = requireNonNullElse(() -> schema.getJsonObject("node").getLong("id"), -1L);
+                private final Long id           = requireNonNull(() -> schema.getJsonObject("node").getLong("id"));
                 private final String firstName  = requireNonNull(() -> schema.getJsonObject("node").getString("first_name"));
                 private final String lastName   = requireNonNull(() -> schema.getJsonObject("node").getString("last_name"));
                 private final String role       = requireNonNull(() -> schema.getString("role"));
@@ -1430,7 +1441,7 @@ abstract class MyAnimeListAPIResponseMapping {
         static Publisher asPublisher(final MyAnimeList mal, final JsonObject schema){
             return new Publisher() {
 
-                private final long id       = requireNonNullElse(() -> schema.getJsonObject("node").getLong("id"), -1L);
+                private final Long id       = requireNonNull(() -> schema.getJsonObject("node").getLong("id"));
                 private final String name   = requireNonNull(() -> schema.getJsonObject("node").getString("name"));
                 private final String role   = requireNonNull(() -> schema.getString("role"));
 
@@ -1464,34 +1475,40 @@ abstract class MyAnimeListAPIResponseMapping {
         static com.kttdevelopment.mal4j.manga.Manga asManga(final MyAnimeList mal, final JsonObject schema){
             return new com.kttdevelopment.mal4j.manga.Manga() {
 
-                private final long id               = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
                 private final String title          = requireNonNull(() -> schema.getString("title"));
                 private final Picture mainPicture   = requireNonNull(() -> Common.asPicture(mal, schema.getJsonObject("main_picture")));
-                private final AlternativeTitles alternativeTitles = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long endDate          = requireNonNullElse(() -> parseDate(schema.getString("end_date")), -1L);
+                private final AlternativeTitles alternativeTitles
+                                                    = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
+                private final Long startDate        = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long endDate          = requireNonNull(() -> parseDate(schema.getString("end_date")));
                 private final String synopsis       = requireNonNull(() -> schema.getString("synopsis"));
-                private final float meanRating      = requireNonNullElse(() -> schema.getFloat("mean"), 0F);
-                private final int rank              = requireNonNullElse(() -> schema.getInt("rank"), -1);
-                private final int popularity        = requireNonNullElse(() -> schema.getInt("popularity"), -1);
-                private final int usersListing      = requireNonNullElse(() -> schema.getInt("num_list_users"), -1);
-                private final int usersScoring      = requireNonNullElse(() -> schema.getInt("num_scoring_users"), -1);
+                private final Float meanRating      = requireNonNull(() -> schema.getFloat("mean"));
+                private final Integer rank          = requireNonNull(() -> schema.getInt("rank"));
+                private final Integer popularity    = requireNonNull(() -> schema.getInt("popularity"));
+                private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
+                private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
                 private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
-                private final long createdAt        = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
+                private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
+                private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final MangaType type        = requireNonNull(() -> MangaType.asEnum(schema.getString("media_type")));
-                private final MangaPublishStatus status = requireNonNull(() -> MangaPublishStatus.asEnum(schema.getString("status")));
-                private final MangaListStatus listStatus = requireNonNull(() -> asMangaListStatus(mal, schema.getJsonObject("my_list_status"), this));
-                private final int volumes           = requireNonNullElse(() -> schema.getInt("num_volumes"), -1);
-                private final int chapters          = requireNonNullElse(() -> schema.getInt("num_chapters"), -1);
+                private final MangaPublishStatus status
+                                                    = requireNonNull(() -> MangaPublishStatus.asEnum(schema.getString("status")));
+                private final MangaListStatus listStatus
+                                                    = requireNonNull(() -> asMangaListStatus(mal, schema.getJsonObject("my_list_status"), this));
+                private final Integer volumes       = requireNonNull(() -> schema.getInt("num_volumes"));
+                private final Integer chapters      = requireNonNull(() -> schema.getInt("num_chapters"));
                 private final Author[] authors      = requireNonNull(() -> adaptList(schema.getJsonArray("authors"), a -> asAuthor(mal, a), Author.class));
                 private final Picture[] pictures    = requireNonNull(() -> adaptList(schema.getJsonArray("pictures"), p -> Common.asPicture(mal, p), Picture.class));
                 private final String background     = requireNonNull(() -> schema.getString("background"));
-                private final RelatedAnime[] relatedAnime = requireNonNull(() -> adaptList(schema.getJsonArray("related_anime"), a -> Anime.asRelatedAnime(mal, a), RelatedAnime.class));
-                private final RelatedManga[] relatedManga = requireNonNull(() -> adaptList(schema.getJsonArray("related_manga"), m -> asRelatedManga(mal, m), RelatedManga.class));
+                private final RelatedAnime[] relatedAnime
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("related_anime"), a -> Anime.asRelatedAnime(mal, a), RelatedAnime.class));
+                private final RelatedManga[] relatedManga
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("related_manga"), m -> asRelatedManga(mal, m), RelatedManga.class));
                 private final MangaRecommendation[] recommendations = requireNonNull(() -> adaptList(schema.getJsonArray("recommendations"), r -> asMangaRecommendation(mal, r), MangaRecommendation.class));
-                private final Publisher[] serialization   = requireNonNull(() -> adaptList(schema.getJsonArray("serialization"), s -> asPublisher(mal, s), Publisher.class));
+                private final Publisher[] serialization
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("serialization"), s -> asPublisher(mal, s), Publisher.class));
 
                 // API methods
 
@@ -1669,20 +1686,20 @@ abstract class MyAnimeListAPIResponseMapping {
         static MangaListStatus asMangaListStatus(final MyAnimeList mal, final JsonObject schema, final long manga_id){
             return new MangaListStatus() {
 
-                private final long id               = requireNonNullElse(() -> manga_id, -1L);
-                private final MangaStatus status    = requireNonNull(() -> MangaStatus.asEnum(schema.getString("status")));
-                private final int score             = requireNonNullElse(() -> schema.getInt("score"), -1);
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long finishDate       = requireNonNullElse(() -> parseDate(schema.getString("finish_date")), -1L);
-                private final Priority priority     = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
-                private final String[] tags         = requireNonNull(() -> schema.getStringArray("tags"));
-                private final String comments       = requireNonNull(() -> schema.getString("comments"));
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
-                private final int volumesRead       = requireNonNullElse(() -> schema.getInt("num_volumes_read"), -1);
-                private final int chaptersRead      = requireNonNullElse(() -> schema.getInt("num_chapters_read"), -1);
-                private final boolean rereading     = requireNonNullElse(() -> (boolean) schema.get("is_rereading"), false);
-                private final int timesReread       = requireNonNullElse(() -> schema.getInt("num_times_reread"), -1);
-                private final RereadValue rereadValue  = requireNonNull(() -> RereadValue.asEnum(schema.getInt("reread_value")));
+                private final Long id                   = requireNonNull(() -> manga_id);
+                private final MangaStatus status        = requireNonNull(() -> MangaStatus.asEnum(schema.getString("status")));
+                private final Integer score             = requireNonNull(() -> schema.getInt("score"));
+                private final Long startDate            = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long finishDate           = requireNonNull(() -> parseDate(schema.getString("finish_date")));
+                private final Priority priority         = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
+                private final String[] tags             = requireNonNull(() -> schema.getStringArray("tags"));
+                private final String comments           = requireNonNull(() -> schema.getString("comments"));
+                private final Long updatedAt            = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
+                private final Integer volumesRead       = requireNonNull(() -> schema.getInt("num_volumes_read"));
+                private final Integer chaptersRead      = requireNonNull(() -> schema.getInt("num_chapters_read"));
+                private final Boolean rereading         = requireNonNull(() -> schema.getBoolean("is_rereading"));
+                private final Integer timesReread       = requireNonNull(() -> schema.getInt("num_times_reread"));
+                private final RereadValue rereadValue   = requireNonNull(() -> RereadValue.asEnum(schema.getInt("reread_value")));
 
                 // API methods
 
@@ -1794,19 +1811,19 @@ abstract class MyAnimeListAPIResponseMapping {
         static MangaListStatus asMangaListStatus(final MyAnimeList mal, final JsonObject schema, final MangaPreview manga){
             return new MangaListStatus() {
 
-                private final MangaStatus status    = requireNonNull(() -> MangaStatus.asEnum(schema.getString("status")));
-                private final int score             = requireNonNullElse(() -> schema.getInt("score"), -1);
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long finishDate       = requireNonNullElse(() -> parseDate(schema.getString("finish_date")), -1L);
-                private final Priority priority     = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
-                private final String[] tags         = requireNonNull(() -> schema.getStringArray("tags"));
-                private final String comments       = requireNonNull(() -> schema.getString("comments"));
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
-                private final int volumesRead       = requireNonNullElse(() -> schema.getInt("num_volumes_read"), -1);
-                private final int chaptersRead      = requireNonNullElse(() -> schema.getInt("num_chapters_read"), -1);
-                private final boolean rereading     = requireNonNullElse(() -> (boolean) schema.get("is_rereading"), false);
-                private final int timesReread       = requireNonNullElse(() -> schema.getInt("num_times_reread"), -1);
-                private final RereadValue rereadValue = requireNonNull(() -> RereadValue.asEnum(schema.getInt("reread_value")));
+                private final MangaStatus status        = requireNonNull(() -> MangaStatus.asEnum(schema.getString("status")));
+                private final Integer score             = requireNonNull(() -> schema.getInt("score"));
+                private final Long startDate            = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long finishDate           = requireNonNull(() -> parseDate(schema.getString("finish_date")));
+                private final Priority priority         = requireNonNull(() -> Priority.asEnum(schema.getInt("priority")));
+                private final String[] tags             = requireNonNull(() -> schema.getStringArray("tags"));
+                private final String comments           = requireNonNull(() -> schema.getString("comments"));
+                private final Long updatedAt            = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
+                private final Integer volumesRead       = requireNonNull(() -> schema.getInt("num_volumes_read"));
+                private final Integer chaptersRead      = requireNonNull(() -> schema.getInt("num_chapters_read"));
+                private final Boolean rereading         = requireNonNull(() -> schema.getBoolean("is_rereading"));
+                private final Integer timesReread       = requireNonNull(() -> schema.getInt("num_times_reread"));
+                private final RereadValue rereadValue   = requireNonNull(() -> RereadValue.asEnum(schema.getInt("reread_value")));
 
                 // API methods
 
@@ -1918,27 +1935,30 @@ abstract class MyAnimeListAPIResponseMapping {
         static MangaPreview asMangaPreview(final MyAnimeList mal, final JsonObject schema){
             return new MangaPreview() {
 
-                private final long id               = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id               = requireNonNull(() -> schema.getLong("id"));
                 private final String title          = requireNonNull(() -> schema.getString("title"));
                 private final Picture mainPicture   = requireNonNull(() -> Common.asPicture(mal, schema.getJsonObject("main_picture")));
-                private final AlternativeTitles alternativeTitles = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
-                private final long startDate        = requireNonNullElse(() -> parseDate(schema.getString("start_date")), -1L);
-                private final long endDate          = requireNonNullElse(() -> parseDate(schema.getString("end_date")), -1L);
+                private final AlternativeTitles alternativeTitles
+                                                    = requireNonNull(() -> Common.asAlternativeTitles(mal, schema.getJsonObject("alternative_titles")));
+                private final Long startDate        = requireNonNull(() -> parseDate(schema.getString("start_date")));
+                private final Long endDate          = requireNonNull(() -> parseDate(schema.getString("end_date")));
                 private final String synopsis       = requireNonNull(() -> schema.getString("synopsis"));
-                private final float meanRating      = requireNonNullElse(() -> schema.getFloat("mean"), 0F);
-                private final int rank              = requireNonNullElse(() -> schema.getInt("rank"), -1);
-                private final int popularity        = requireNonNullElse(() -> schema.getInt("popularity"), -1);
-                private final int usersListing      = requireNonNullElse(() -> schema.getInt("num_list_users"), -1);
-                private final int usersScoring      = requireNonNullElse(() -> schema.getInt("num_scoring_users"), -1);
+                private final Float meanRating      = requireNonNull(() -> schema.getFloat("mean"));
+                private final Integer rank          = requireNonNull(() -> schema.getInt("rank"));
+                private final Integer popularity    = requireNonNull(() -> schema.getInt("popularity"));
+                private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
+                private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
                 private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
-                private final long createdAt        = requireNonNullElse(() -> parseISO8601(schema.getString("created_at")), -1L);
-                private final long updatedAt        = requireNonNullElse(() -> parseISO8601(schema.getString("updated_at")), -1L);
+                private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
+                private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final MangaType type        = requireNonNull(() -> MangaType.asEnum(schema.getString("media_type")));
-                private final MangaPublishStatus status = requireNonNull(() -> MangaPublishStatus.asEnum(schema.getString("status")));
-                private final MangaListStatus listStatus = requireNonNull(() -> asMangaListStatus(mal, schema.getJsonObject("my_list_status"), this));
-                private final int volumes           = requireNonNullElse(() -> schema.getInt("num_volumes"), -1);
-                private final int chapters          = requireNonNullElse(() -> schema.getInt("num_chapters"), -1);
+                private final MangaPublishStatus status
+                                                    = requireNonNull(() -> MangaPublishStatus.asEnum(schema.getString("status")));
+                private final MangaListStatus listStatus
+                                                    = requireNonNull(() -> asMangaListStatus(mal, schema.getJsonObject("my_list_status"), this));
+                private final Integer volumes       = requireNonNull(() -> schema.getInt("num_volumes"));
+                private final Integer chapters      = requireNonNull(() -> schema.getInt("num_chapters"));
                 private final Author[] authors      = requireNonNull(() -> adaptList(schema.getJsonArray("authors"), a -> asAuthor(mal, a), Author.class));
 
                 // API methods
@@ -2091,9 +2111,9 @@ abstract class MyAnimeListAPIResponseMapping {
         static MangaRanking asMangaRanking(final MyAnimeList mal, final JsonObject schema){
             return new MangaRanking() {
 
-                private final MangaPreview manga    = requireNonNull(() -> asMangaPreview(mal, schema.getJsonObject("node")));
-                private final int ranking           = requireNonNullElse(() -> schema.getJsonObject("ranking").getInt("rank"), -1);
-                private final int previousRanking   = requireNonNullElse(() -> schema.getJsonObject("ranking").getInt("previous_rank"), -1);
+                private final MangaPreview manga        = requireNonNull(() -> asMangaPreview(mal, schema.getJsonObject("node")));
+                private final Integer ranking           = requireNonNull(() -> schema.getJsonObject("ranking").getInt("rank"));
+                private final Integer previousRanking   = requireNonNull(() -> schema.getJsonObject("ranking").getInt("previous_rank"));
 
                 // API method
 
@@ -2130,8 +2150,8 @@ abstract class MyAnimeListAPIResponseMapping {
         static MangaRecommendation asMangaRecommendation(final MyAnimeList mal, final JsonObject schema){
             return new MangaRecommendation() {
 
-                private final MangaPreview manga    = requireNonNull(() -> asMangaPreview(mal, schema.getJsonObject("node")));
-                private final int recommendations   = requireNonNullElse(() -> schema.getInt("num_recommendations"), -1);
+                private final MangaPreview manga        = requireNonNull(() -> asMangaPreview(mal, schema.getJsonObject("node")));
+                private final Integer recommendations   = requireNonNull(() -> schema.getInt("num_recommendations"));
 
                 // API methods
 
@@ -2206,16 +2226,17 @@ abstract class MyAnimeListAPIResponseMapping {
         static com.kttdevelopment.mal4j.user.User asUser(final MyAnimeList mal, final JsonObject schema){
             return new com.kttdevelopment.mal4j.user.User() {
 
-                private final long id           = requireNonNullElse(() -> schema.getLong("id"), -1L);
+                private final Long id           = requireNonNull(() -> schema.getLong("id"));
                 private final String name       = requireNonNull(() -> schema.getString("name"));
                 private final String picture    = requireNonNull(() -> schema.getString("picture"));
                 private final String gender     = requireNonNull(() -> schema.getString("gender"));
-                private final long birthday     = requireNonNullElse(() -> parseDate(schema.getString("birthday")), -1L);
+                private final Long birthday     = requireNonNull(() -> parseDate(schema.getString("birthday")));
                 private final String location   = requireNonNull(() -> schema.getString("location"));
-                private final long joinedAt     = requireNonNullElse(() -> parseISO8601(schema.getString("joined_at")), -1L);
-                private final UserAnimeStatistics animeStatistics = requireNonNull(() -> asUserAnimeStatistics(mal, schema.getJsonObject("anime_statistics")));
+                private final Long joinedAt     = requireNonNull(() -> parseISO8601(schema.getString("joined_at")));
+                private final UserAnimeStatistics animeStatistics
+                                                = requireNonNull(() -> asUserAnimeStatistics(mal, schema.getJsonObject("anime_statistics")));
                 private final String timezone   = requireNonNull(() -> schema.getString("time_zone"));
-                private final boolean supporter = requireNonNullElse(() -> (boolean) schema.get("is_supporter"), false);
+                private final Boolean supporter = requireNonNull(() -> schema.getBoolean("is_supporter"));
 
                 // API methods
 
@@ -2292,21 +2313,21 @@ abstract class MyAnimeListAPIResponseMapping {
         static UserAnimeStatistics asUserAnimeStatistics(final MyAnimeList mal, final JsonObject schema){
             return new UserAnimeStatistics() {
 
-                private final int watching          = requireNonNullElse(() -> schema.getInt("num_items_watching"), -1);
-                private final int completed         = requireNonNullElse(() -> schema.getInt("num_items_completed"), -1);
-                private final int onHold            = requireNonNullElse(() -> schema.getInt("num_items_on_hold"), -1);
-                private final int dropped           = requireNonNullElse(() -> schema.getInt("num_items_dropped"), -1);
-                private final int planToWatch       = requireNonNullElse(() -> schema.getInt("num_items_plan_to_watch"), -1);
-                private final int items             = requireNonNullElse(() -> schema.getInt("num_items"), -1);
-                private final float daysWatching    = requireNonNullElse(() -> schema.getFloat("num_days_watching"), 0f);
-                private final float daysCompleted   = requireNonNullElse(() -> schema.getFloat("num_days_completed"), 0f);
-                private final float daysOnHold      = requireNonNullElse(() -> schema.getFloat("num_days_on_hold"), 0f);
-                private final float daysDropped     = requireNonNullElse(() -> schema.getFloat("num_days_dropped"), 0f);
-                private final float days            = requireNonNullElse(() -> schema.getFloat("num_days"), 0f);
-                private final int episodesWatched   = requireNonNullElse(() -> schema.getInt("num_episodes"), -1);
+                private final Integer watching          = requireNonNull(() -> schema.getInt("num_items_watching"));
+                private final Integer completed         = requireNonNull(() -> schema.getInt("num_items_completed"));
+                private final Integer onHold            = requireNonNull(() -> schema.getInt("num_items_on_hold"));
+                private final Integer dropped           = requireNonNull(() -> schema.getInt("num_items_dropped"));
+                private final Integer planToWatch       = requireNonNull(() -> schema.getInt("num_items_plan_to_watch"));
+                private final Integer items             = requireNonNull(() -> schema.getInt("num_items"));
+                private final Float daysWatching        = requireNonNull(() -> schema.getFloat("num_days_watching"));
+                private final Float daysCompleted       = requireNonNull(() -> schema.getFloat("num_days_completed"));
+                private final Float daysOnHold          = requireNonNull(() -> schema.getFloat("num_days_on_hold"));
+                private final Float daysDropped         = requireNonNull(() -> schema.getFloat("num_days_dropped"));
+                private final Float days                = requireNonNull(() -> schema.getFloat("num_days"));
+                private final Integer episodesWatched   = requireNonNull(() -> schema.getInt("num_episodes"));
                 @SuppressWarnings("SpellCheckingInspection")
-                private final int timesRewatched    = requireNonNullElse(() -> schema.getInt("num_times_rewatched"), -1);
-                private final float meanScore       = requireNonNullElse(() -> schema.getFloat("mean_score"), 0f);
+                private final Integer timesRewatched    = requireNonNull(() -> schema.getInt("num_times_rewatched"));
+                private final Float meanScore           = requireNonNull(() -> schema.getFloat("mean_score"));
 
                 // API methods
 
@@ -2518,10 +2539,10 @@ abstract class MyAnimeListAPIResponseMapping {
 
         return new Time() {
 
-            private final int hour   = h;
-            private final int hour12 = h > 12 ? h - 12 : h == 0 ? 12 : h;
-            private final boolean am = hour <= 12;
-            private final int minute = m;
+            private final Integer hour      = h;
+            private final Integer hour12    = h > 12 ? h - 12 : h == 0 ? 12 : h;
+            private final Boolean am        = hour <= 12;
+            private final Integer minute    = m;
 
             @Override
             public final int getHour() {
@@ -2561,15 +2582,10 @@ abstract class MyAnimeListAPIResponseMapping {
     //
 
     private static <T> T requireNonNull(final Supplier<T> obj){
-        return requireNonNullElse(obj, null);
-    }
-
-    private static <T> T requireNonNullElse(final Supplier<T> obj, T defaultObj){
         try{
-            final T response = obj.get();
-            return response != null ? response : defaultObj;
+            return obj.get();
         }catch (final NullPointerException ignored){
-            return defaultObj;
+            return null;
         }
     }
 

--- a/src/main/java/com/kttdevelopment/mal4j/anime/AnimeListStatus.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/AnimeListStatus.java
@@ -51,7 +51,7 @@ public abstract class AnimeListStatus implements ListStatus<AnimeStatus>,AnimeRe
      *
      * @since 1.0.0
      */
-    public abstract int getWatchedEpisodes();
+    public abstract Integer getWatchedEpisodes();
 
     /**
      * Returns if the user is rewatching.
@@ -60,7 +60,7 @@ public abstract class AnimeListStatus implements ListStatus<AnimeStatus>,AnimeRe
      *
      * @since 1.0.0
      */
-    public abstract boolean isRewatching();
+    public abstract Boolean isRewatching();
 
     /**
      * Returns the total times rewatched.
@@ -69,7 +69,7 @@ public abstract class AnimeListStatus implements ListStatus<AnimeStatus>,AnimeRe
      *
      * @since 1.0.0
      */
-    public abstract int getTimesRewatched();
+    public abstract Integer getTimesRewatched();
 
     /**
      * Returns the rewatch value.

--- a/src/main/java/com/kttdevelopment/mal4j/anime/AnimePreview.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/AnimePreview.java
@@ -47,7 +47,7 @@ public abstract class AnimePreview implements AnimeRetrievable,MediaItem<AnimeTy
      *
      * @since 1.0.0
      */
-    public abstract int getEpisodes();
+    public abstract Integer getEpisodes();
 
     /**
      * Returns the Anime start season.
@@ -86,7 +86,7 @@ public abstract class AnimePreview implements AnimeRetrievable,MediaItem<AnimeTy
      *
      * @since 1.0.0
      */
-    public abstract int getAverageEpisodeLength();
+    public abstract Integer getAverageEpisodeLength();
 
     /**
      * Returns the Anime's TV viewing rating (ex: pg13).

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/AnimeStatistics.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/AnimeStatistics.java
@@ -38,7 +38,7 @@ public abstract class AnimeStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getWatching();
+    public abstract Integer getWatching();
 
     /**
      * The total amount of users completed.
@@ -47,7 +47,7 @@ public abstract class AnimeStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getCompleted();
+    public abstract Integer getCompleted();
 
     /**
      * The total amount of users on hold.
@@ -56,7 +56,7 @@ public abstract class AnimeStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getOnHold();
+    public abstract Integer getOnHold();
 
     /**
      * The total amount of users dropped.
@@ -65,7 +65,7 @@ public abstract class AnimeStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getDropped();
+    public abstract Integer getDropped();
 
     /**
      * The total amount of users planning to watch.
@@ -74,6 +74,6 @@ public abstract class AnimeStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getPlanToWatch();
+    public abstract Integer getPlanToWatch();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/StartSeason.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/StartSeason.java
@@ -38,7 +38,7 @@ public abstract class StartSeason {
      *
      * @since 1.0.0
      */
-    public abstract int getYear();
+    public abstract Integer getYear();
 
     /**
      * The broadcast season that the Anime will start in

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/time/Time.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/time/Time.java
@@ -35,7 +35,7 @@ public abstract class Time {
      *
      * @since 1.0.0
      */
-    public abstract int getHour();
+    public abstract Integer getHour();
 
     /**
      * Returns the hour on a 12 hour clock (1-12).
@@ -44,7 +44,7 @@ public abstract class Time {
      *
      * @since 1.0.0
      */
-    public abstract int get12Hour();
+    public abstract Integer get12Hour();
 
     /**
      * Returns if the time is AM.
@@ -55,7 +55,7 @@ public abstract class Time {
      * @see #isPM()
      * @since 1.0.0
      */
-    public abstract boolean isAM();
+    public abstract Boolean isAM();
 
     /**
      * Returns if the time is PM.
@@ -66,7 +66,7 @@ public abstract class Time {
      * @see #isAM()
      * @since 1.0.0
      */
-    public abstract boolean isPM();
+    public abstract Boolean isPM();
 
     /**
      * Returns the minute (0-59).
@@ -75,6 +75,6 @@ public abstract class Time {
      *
      * @since 1.0.0
      */
-    public abstract int getMinute();
+    public abstract Integer getMinute();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/forum/ForumTopicDetail.java
+++ b/src/main/java/com/kttdevelopment/mal4j/forum/ForumTopicDetail.java
@@ -48,7 +48,7 @@ public abstract class ForumTopicDetail implements ID {
      *
      * @since 1.0.0
      */
-    public abstract long getCreatedAt();
+    public abstract Long getCreatedAt();
 
     /**
      * Returns who created the topic.
@@ -67,7 +67,7 @@ public abstract class ForumTopicDetail implements ID {
      *
      * @since 1.0.0
      */
-    public abstract int getPostsCount();
+    public abstract Integer getPostsCount();
 
     /**
      * Returns when the last post was created at.
@@ -76,7 +76,7 @@ public abstract class ForumTopicDetail implements ID {
      *
      * @since 1.0.0
      */
-    public abstract long getLastPostCreatedAt();
+    public abstract Long getLastPostCreatedAt();
 
     /**
      * Returns who the last post was created by.
@@ -95,6 +95,6 @@ public abstract class ForumTopicDetail implements ID {
      *
      * @since 1.0.0
      */
-    public abstract boolean isLocked();
+    public abstract Boolean isLocked();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/forum/Post.java
+++ b/src/main/java/com/kttdevelopment/mal4j/forum/Post.java
@@ -40,7 +40,7 @@ public abstract class Post implements ID {
      *
      * @since 1.0.0
      */
-    public abstract int getNumber();
+    public abstract Integer getNumber();
 
     /**
      * Returns when the post was created at.
@@ -49,7 +49,7 @@ public abstract class Post implements ID {
      *
      * @since 1.0.0
      */
-    public abstract long getCreatedAt();
+    public abstract Long getCreatedAt();
 
     /**
      * Returns the post author.

--- a/src/main/java/com/kttdevelopment/mal4j/forum/property/Poll.java
+++ b/src/main/java/com/kttdevelopment/mal4j/forum/property/Poll.java
@@ -51,7 +51,7 @@ public abstract class Poll implements ID {
      *
      * @since 1.0.0
      */
-    public abstract boolean isClosed();
+    public abstract Boolean isClosed();
 
     /**
      * Returns the poll's options.

--- a/src/main/java/com/kttdevelopment/mal4j/forum/property/PollOption.java
+++ b/src/main/java/com/kttdevelopment/mal4j/forum/property/PollOption.java
@@ -49,7 +49,7 @@ public abstract class PollOption implements ID {
      *
      * @since 1.0.0
      */
-    public abstract int getVotes();
+    public abstract Integer getVotes();
 
     // additional methods
 

--- a/src/main/java/com/kttdevelopment/mal4j/manga/MangaListStatus.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/MangaListStatus.java
@@ -50,7 +50,7 @@ public abstract class MangaListStatus implements ListStatus<MangaStatus>,MangaRe
      *
      * @since 1.0.0
      */
-    public abstract int getVolumesRead();
+    public abstract Integer getVolumesRead();
 
     /**
      * Returns the total amount of chapters read.
@@ -59,7 +59,7 @@ public abstract class MangaListStatus implements ListStatus<MangaStatus>,MangaRe
      *
      * @since 1.0.0
      */
-    public abstract int getChaptersRead();
+    public abstract Integer getChaptersRead();
 
     /**
      * Returns if the user is rereading.
@@ -68,7 +68,7 @@ public abstract class MangaListStatus implements ListStatus<MangaStatus>,MangaRe
      *
      * @since 1.0.0
      */
-    public abstract boolean isRereading();
+    public abstract Boolean isRereading();
 
     /**
      * Returns the total times reread.
@@ -77,7 +77,7 @@ public abstract class MangaListStatus implements ListStatus<MangaStatus>,MangaRe
      *
      * @since 1.0.0
      */
-    public abstract int getTimesReread();
+    public abstract Integer getTimesReread();
 
     /**
      * Returns the reread value.

--- a/src/main/java/com/kttdevelopment/mal4j/manga/MangaPreview.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/MangaPreview.java
@@ -47,7 +47,7 @@ public abstract class MangaPreview implements MangaRetrievable,MediaItem<MangaTy
      * @see #getChapters()
      * @since 1.0.0
      */
-    public abstract int getVolumes();
+    public abstract Integer getVolumes();
 
     /**
      * Returns the total amount of chapters.
@@ -57,7 +57,7 @@ public abstract class MangaPreview implements MangaRetrievable,MediaItem<MangaTy
      * @see #getVolumes()
      * @since 1.0.0
      */
-    public abstract int getChapters();
+    public abstract Integer getChapters();
 
     /**
      * Returns the Manga's authors.

--- a/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaStatistics.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaStatistics.java
@@ -39,7 +39,7 @@ public abstract class MangaStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getReading();
+    public abstract Integer getReading();
 
     /**
      * Returns the total users completed.
@@ -48,7 +48,7 @@ public abstract class MangaStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getCompleted();
+    public abstract Integer getCompleted();
 
     /**
      * Returns the total users on hold.
@@ -57,7 +57,7 @@ public abstract class MangaStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getOnHold();
+    public abstract Integer getOnHold();
 
      /**
      * Returns the total users dropped.
@@ -66,7 +66,7 @@ public abstract class MangaStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getDropped();
+    public abstract Integer getDropped();
 
      /**
      * Returns the total users planning to read.
@@ -75,6 +75,6 @@ public abstract class MangaStatistics extends Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getPlanToRead();
+    public abstract Integer getPlanToRead();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/property/ID.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/ID.java
@@ -34,6 +34,6 @@ public interface ID {
      *
      * @since 1.0.0
      */
-    long getID();
+    Long getID();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/property/ListStatus.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/ListStatus.java
@@ -51,7 +51,7 @@ public interface ListStatus<Status extends Enum<?>> {
      *
      * @since 1.0.0
      */
-    int getScore();
+    Integer getScore();
 
     /**
      * Returns the start date for the listing.
@@ -75,7 +75,7 @@ public interface ListStatus<Status extends Enum<?>> {
      * @see #getFinishDateEpochMillis()
      * @since 1.0.0
      */
-    long getStartDateEpochMillis();
+    Long getStartDateEpochMillis();
 
     /**
      * Returns the finish date for the listing.
@@ -99,7 +99,7 @@ public interface ListStatus<Status extends Enum<?>> {
      * @see #getStartDateEpochMillis()
      * @since 1.0.0
      */
-    long getFinishDateEpochMillis();
+    Long getFinishDateEpochMillis();
 
     /**
      * Returns the priority for the listing.
@@ -147,6 +147,6 @@ public interface ListStatus<Status extends Enum<?>> {
      * @see #getUpdatedAt()
      * @since 1.0.0
      */
-    long getUpdatedAtEpochMillis();
+    Long getUpdatedAtEpochMillis();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/property/MediaItem.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/MediaItem.java
@@ -84,7 +84,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      * @see #getEndDateEpochMillis()
      * @since 1.0.0
      */
-    long getStartDateEpochMillis();
+    Long getStartDateEpochMillis();
 
     /**
      * Returns the end date.
@@ -107,7 +107,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      * @see #getStartDate()
      * @see #getStartDateEpochMillis()
      */
-    long getEndDateEpochMillis();
+    Long getEndDateEpochMillis();
 
     /**
      * Returns the synopsis.
@@ -125,7 +125,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      *
      * @since 1.0.0
      */
-    float getMeanRating();
+    Float getMeanRating();
 
     /**
      * Returns the overall rank.
@@ -134,7 +134,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      *
      * @since 1.0.0
      */
-    int getRank();
+    Integer getRank();
 
     /**
      * Returns the popularity.
@@ -143,7 +143,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      *
      * @since 1.0.0
      */
-    int getPopularity();
+    Integer getPopularity();
 
     /**
      * Returns how many users have this item on their list.
@@ -152,7 +152,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      *
      * @since 1.0.0
      */
-    int getUserListingCount();
+    Integer getUserListingCount();
 
     /**
      * Returns how many users have this item scored on their list.
@@ -161,7 +161,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      *
      * @since 1.0.0
      */
-    int getUserScoringCount();
+    Integer getUserScoringCount();
 
     /**
      * Returns the NSFW rating.
@@ -204,7 +204,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      * @see #getUpdatedAt()
      * @since 1.0.0
      */
-    long getCreatedAtEpochMillis();
+    Long getCreatedAtEpochMillis();
 
     /**
      * Returns when this was last updated.
@@ -228,7 +228,7 @@ public interface MediaItem<MediaType extends Enum<?>,Status extends Enum<?>,List
      * @see #getCreatedAtEpochMillis()
      * @since 1.0.0
      */
-    long getUpdatedAtEpochMillis();
+    Long getUpdatedAtEpochMillis();
 
     /**
      * Returns the media type.

--- a/src/main/java/com/kttdevelopment/mal4j/property/Ranking.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Ranking.java
@@ -35,7 +35,7 @@ public interface Ranking {
      * @see #getPreviousRank()
      * @since 1.0.0
      */
-    int getRanking();
+    Integer getRanking();
 
     /**
      * Returns the item's previous ranking.
@@ -45,6 +45,6 @@ public interface Ranking {
      * @see #getRanking()
      * @since 1.0.0
      */
-    int getPreviousRank();
+    Integer getPreviousRank();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/property/Recommendation.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Recommendation.java
@@ -36,6 +36,6 @@ public abstract class Recommendation {
      *
      * @since 1.0.0
      */
-    public abstract int getRecommendations();
+    public abstract Integer getRecommendations();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/property/Statistics.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Statistics.java
@@ -37,6 +37,6 @@ public abstract class Statistics {
      *
      * @since 1.0.0
      */
-    public abstract int getUserCount();
+    public abstract Integer getUserCount();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/query/ForumSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/mal4j/query/ForumSearchQuery.java
@@ -36,6 +36,7 @@ public abstract class ForumSearchQuery extends SearchQuery<ForumSearchQuery,Foru
     protected String query;
     @SuppressWarnings({"SpellCheckingInspection", "RedundantSuppression"})
     protected Long boardId, subboardId;
+    @SuppressWarnings("CanBeFinal")
     protected ForumSort sort = ForumSort.Recent;
     protected String topicUsername, username;
     

--- a/src/main/java/com/kttdevelopment/mal4j/user/User.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/User.java
@@ -73,7 +73,7 @@ public abstract class User implements IDN {
      * @see #getBirthday()
      * @since 1.0.0
      */
-    public abstract long getBirthdayEpochMillis();
+    public abstract Long getBirthdayEpochMillis();
 
     /**
      * Returns the user's location.
@@ -102,7 +102,7 @@ public abstract class User implements IDN {
      * @see #getJoinedAt()
      * @since 1.0.0
      */
-    public abstract long getJoinedAtEpochMillis();
+    public abstract Long getJoinedAtEpochMillis();
 
     /**
      * Returns the user's Anime statistics.
@@ -130,6 +130,6 @@ public abstract class User implements IDN {
      *
      * @since 1.0.0
      */
-    public abstract boolean isSupporter();
+    public abstract Boolean isSupporter();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/user/UserAnimeStatistics.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/UserAnimeStatistics.java
@@ -35,7 +35,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsWatching();
+    public abstract Integer getItemsWatching();
 
     /**
      * Returns total items completed.
@@ -44,7 +44,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsCompleted();
+    public abstract Integer getItemsCompleted();
 
     /**
      * Returns total items on hold.
@@ -53,7 +53,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsOnHold();
+    public abstract Integer getItemsOnHold();
 
     /**
      * Returns total items dropped.
@@ -62,7 +62,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsDropped();
+    public abstract Integer getItemsDropped();
 
     /**
      * Returns total items planned to watch.
@@ -71,7 +71,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsPlanToWatch();
+    public abstract Integer getItemsPlanToWatch();
 
     /**
      * Returns total items.
@@ -80,7 +80,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItems();
+    public abstract Integer getItems();
 
     /**
      * Returns total days watched.
@@ -89,7 +89,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysWatched();
+    public abstract Float getDaysWatched();
 
     /**
      * Returns total days watching.
@@ -98,7 +98,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysWatching();
+    public abstract Float getDaysWatching();
 
     /**
      * Returns total days completed.
@@ -107,7 +107,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysCompleted();
+    public abstract Float getDaysCompleted();
 
     /**
      * Returns total days on hold.
@@ -116,7 +116,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysOnHold();
+    public abstract Float getDaysOnHold();
 
     /**
      * Returns total days dropped.
@@ -125,7 +125,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysDropped();
+    public abstract Float getDaysDropped();
 
     /**
      * Returns total days.
@@ -134,7 +134,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDays();
+    public abstract Float getDays();
 
     /**
      * Returns total episodes watched.
@@ -143,7 +143,7 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getEpisodes();
+    public abstract Integer getEpisodes();
 
     /**
      * Returns times rewatched.
@@ -153,7 +153,7 @@ public abstract class UserAnimeStatistics {
      * @since 1.0.0
      */
     @SuppressWarnings("SpellCheckingInspection")
-    public abstract int getTimesRewatched();
+    public abstract Integer getTimesRewatched();
 
     /**
      * Returns the average score.
@@ -162,6 +162,6 @@ public abstract class UserAnimeStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getMeanScore();
+    public abstract Float getMeanScore();
 
 }

--- a/src/main/java/com/kttdevelopment/mal4j/user/UserMangaStatistics.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/UserMangaStatistics.java
@@ -36,7 +36,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsReading();
+    public abstract Integer getItemsReading();
 
     /**
      * Returns total items completed.
@@ -45,7 +45,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsCompleted();
+    public abstract Integer getItemsCompleted();
 
     /**
      * Returns total items on hold.
@@ -54,7 +54,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsOnHold();
+    public abstract Integer getItemsOnHold();
 
     /**
      * Returns total items dropped.
@@ -63,7 +63,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsDropped();
+    public abstract Integer getItemsDropped();
 
     /**
      * Returns total items planned to read.
@@ -72,7 +72,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItemsPlanToRead();
+    public abstract Integer getItemsPlanToRead();
 
     /**
      * Returns total items.
@@ -81,7 +81,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getItems();
+    public abstract Integer getItems();
 
     /**
      * Returns total days read.
@@ -90,7 +90,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysWatched();
+    public abstract Float getDaysWatched();
 
     /**
      * Returns total days reading.
@@ -99,7 +99,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysReading();
+    public abstract Float getDaysReading();
 
     /**
      * Returns total days completed.
@@ -108,7 +108,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysCompleted();
+    public abstract Float getDaysCompleted();
 
     /**
      * Returns total days on hold.
@@ -117,7 +117,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysOnHold();
+    public abstract Float getDaysOnHold();
 
     /**
      * Returns total days dropped.
@@ -126,7 +126,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDaysDropped();
+    public abstract Float getDaysDropped();
 
     /**
      * Returns total days.
@@ -135,7 +135,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getDays();
+    public abstract Float getDays();
 
     /**
      * Returns total volumes read.
@@ -144,7 +144,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getVolumes();
+    public abstract Integer getVolumes();
 
     /**
      * Returns total chapters read.
@@ -153,7 +153,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getChapters();
+    public abstract Integer getChapters();
 
     /**
      * Returns times reread
@@ -162,7 +162,7 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract int getTimesReread();
+    public abstract Integer getTimesReread();
 
     /**
      * Returns the average score.
@@ -171,6 +171,6 @@ public abstract class UserMangaStatistics {
      *
      * @since 1.0.0
      */
-    public abstract float getMeanScore();
+    public abstract Float getMeanScore();
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -31,34 +31,34 @@ public class TestAnime {
         Assertions.assertNotNull(anime.getAlternativeTitles().getEnglish());
         Assertions.assertNotNull(anime.getAlternativeTitles().getJapanese());
         Assertions.assertNotNull(anime.getAlternativeTitles().getSynonyms());
-        Assertions.assertDoesNotThrow(() -> anime.getStartDate().getTime());
-        Assertions.assertDoesNotThrow(() -> anime.getStartDateEpochMillis());
-        Assertions.assertDoesNotThrow(() -> anime.getEndDate().getTime());
-        Assertions.assertDoesNotThrow(() -> anime.getEndDateEpochMillis());
+        Assertions.assertNotNull(anime.getStartDate());
+        Assertions.assertNotNull(anime.getStartDateEpochMillis());
+        Assertions.assertNotNull(anime.getEndDate());
+        Assertions.assertNotNull(anime.getEndDateEpochMillis());
         Assertions.assertNotNull(anime.getSynopsis());
-        Assertions.assertDoesNotThrow(() -> anime.getMeanRating());
-        Assertions.assertDoesNotThrow(() -> anime.getRank());
-        Assertions.assertDoesNotThrow(() -> anime.getPopularity());
-        Assertions.assertDoesNotThrow(() -> anime.getUserListingCount());
-        Assertions.assertDoesNotThrow(() -> anime.getUserScoringCount());
+        Assertions.assertNotNull(anime.getMeanRating());
+        Assertions.assertNotNull(anime.getRank());
+        Assertions.assertNotNull(anime.getPopularity());
+        Assertions.assertNotNull(anime.getUserListingCount());
+        Assertions.assertNotNull(anime.getUserScoringCount());
         Assertions.assertNotNull(anime.getNSFW());
-        Assertions.assertDoesNotThrow(() -> anime.getGenres()[0].getId());
+        Assertions.assertNotNull(anime.getGenres()[0]);
         Assertions.assertNotNull(anime.getGenres()[0].getName());
-        Assertions.assertDoesNotThrow(() -> anime.getCreatedAt().getTime());
-        Assertions.assertDoesNotThrow(() -> anime.getCreatedAtEpochMillis());
-        Assertions.assertDoesNotThrow(() -> anime.getUpdatedAt().getTime());
-        Assertions.assertDoesNotThrow(() -> anime.getUpdatedAtEpochMillis());
+        Assertions.assertNotNull(anime.getCreatedAt());
+        Assertions.assertNotNull(anime.getCreatedAtEpochMillis());
+        Assertions.assertNotNull(anime.getUpdatedAt());
+        Assertions.assertNotNull(anime.getUpdatedAtEpochMillis());
         Assertions.assertNotNull(anime.getType());
         Assertions.assertNotNull(anime.getStatus());
-        Assertions.assertDoesNotThrow(() -> anime.getEpisodes());
+        Assertions.assertNotNull(anime.getEpisodes());
         Assertions.assertNotNull(anime.getStartSeason().getSeason());
-        Assertions.assertDoesNotThrow(() -> anime.getStartSeason().getYear());
+        Assertions.assertNotNull(anime.getStartSeason().getYear());
         Assertions.assertNotNull(anime.getBroadcast().getDayOfWeek());
         Assertions.assertNotNull(anime.getBroadcast().getStartTime());
         Assertions.assertNotNull(anime.getSource());
-        Assertions.assertDoesNotThrow(() -> anime.getAverageEpisodeLength());
+        Assertions.assertNotNull(anime.getAverageEpisodeLength());
         Assertions.assertNotNull(anime.getRating());
-        Assertions.assertDoesNotThrow(() -> anime.getStudios()[0].getID());
+        Assertions.assertNotNull(anime.getStudios()[0].getID());
         Assertions.assertNotNull(anime.getStudios()[0].getName());
         Assertions.assertNotNull(anime.getPictures()[0].getMediumURL());
         Assertions.assertNotNull(anime.getPictures()[0].getLargeURL());
@@ -68,7 +68,7 @@ public class TestAnime {
     @Test
     public void testRelatedAnime(){
         final RelatedAnime relatedAnime = anime.getRelatedAnime()[0];
-        Assertions.assertDoesNotThrow(() -> relatedAnime.getAnimePreview().getID());
+        Assertions.assertNotNull(relatedAnime.getAnimePreview().getID());
         Assertions.assertNotNull(relatedAnime.getRelationType());
         Assertions.assertNotNull(relatedAnime.getRelationTypeFormat());
     }
@@ -76,7 +76,7 @@ public class TestAnime {
     @Test @DisplayName("Anime may not have related Manga") @Disabled
     public void testRelatedManga(){
         final RelatedManga relatedManga = anime.getRelatedManga()[0];
-        Assertions.assertDoesNotThrow(() -> relatedManga.getMangaPreview().getID());
+        Assertions.assertNotNull(relatedManga.getMangaPreview().getID());
         Assertions.assertNotNull(relatedManga.getRelationType());
         Assertions.assertNotNull(relatedManga.getRelationTypeFormat());
     }
@@ -84,19 +84,19 @@ public class TestAnime {
     @Test
     public void testRecommendations(){
         final AnimeRecommendation recommendation = anime.getRecommendations()[0];
-        Assertions.assertDoesNotThrow(() -> recommendation.getAnimePreview().getID());
-        Assertions.assertDoesNotThrow(recommendation::getRecommendations);
+        Assertions.assertNotNull(recommendation.getAnimePreview().getID());
+        Assertions.assertNotNull(recommendation.getRecommendations());
     }
 
     @Test
     public void testStatistics(){
         final AnimeStatistics statistics = anime.getStatistics();
-        Assertions.assertDoesNotThrow(statistics::getCompleted);
-        Assertions.assertDoesNotThrow(statistics::getDropped);
-        Assertions.assertDoesNotThrow(statistics::getOnHold);
-        Assertions.assertDoesNotThrow(statistics::getPlanToWatch);
-        Assertions.assertDoesNotThrow(statistics::getWatching);
-        Assertions.assertDoesNotThrow(statistics::getUserCount);
+        Assertions.assertNotNull(statistics.getCompleted());
+        Assertions.assertNotNull(statistics.getDropped());
+        Assertions.assertNotNull(statistics.getOnHold());
+        Assertions.assertNotNull(statistics.getPlanToWatch());
+        Assertions.assertNotNull(statistics.getWatching());
+        Assertions.assertNotNull(statistics.getUserCount());
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -31,34 +31,34 @@ public class TestAnime {
         Assertions.assertNotNull(anime.getAlternativeTitles().getEnglish());
         Assertions.assertNotNull(anime.getAlternativeTitles().getJapanese());
         Assertions.assertNotNull(anime.getAlternativeTitles().getSynonyms());
-        Assertions.assertNotEquals(-1, anime.getStartDate().getTime());
-        Assertions.assertNotEquals(-1, anime.getStartDateEpochMillis());
-        Assertions.assertNotEquals(-1, anime.getEndDate().getTime());
-        Assertions.assertNotEquals(-1, anime.getEndDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> anime.getStartDate().getTime());
+        Assertions.assertDoesNotThrow(() -> anime.getStartDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> anime.getEndDate().getTime());
+        Assertions.assertDoesNotThrow(() -> anime.getEndDateEpochMillis());
         Assertions.assertNotNull(anime.getSynopsis());
-        Assertions.assertNotEquals(-1, anime.getMeanRating());
-        Assertions.assertNotEquals(-1, anime.getRank());
-        Assertions.assertNotEquals(-1, anime.getPopularity());
-        Assertions.assertNotEquals(-1, anime.getUserListingCount());
-        Assertions.assertNotEquals(-1, anime.getUserScoringCount());
+        Assertions.assertDoesNotThrow(() -> anime.getMeanRating());
+        Assertions.assertDoesNotThrow(() -> anime.getRank());
+        Assertions.assertDoesNotThrow(() -> anime.getPopularity());
+        Assertions.assertDoesNotThrow(() -> anime.getUserListingCount());
+        Assertions.assertDoesNotThrow(() -> anime.getUserScoringCount());
         Assertions.assertNotNull(anime.getNSFW());
-        Assertions.assertNotEquals(-1, anime.getGenres()[0].getId());
+        Assertions.assertDoesNotThrow(() -> anime.getGenres()[0].getId());
         Assertions.assertNotNull(anime.getGenres()[0].getName());
-        Assertions.assertNotEquals(-1, anime.getCreatedAt().getTime());
-        Assertions.assertNotEquals(-1, anime.getCreatedAtEpochMillis());
-        Assertions.assertNotEquals(-1, anime.getUpdatedAt().getTime());
-        Assertions.assertNotEquals(-1, anime.getUpdatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> anime.getCreatedAt().getTime());
+        Assertions.assertDoesNotThrow(() -> anime.getCreatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> anime.getUpdatedAt().getTime());
+        Assertions.assertDoesNotThrow(() -> anime.getUpdatedAtEpochMillis());
         Assertions.assertNotNull(anime.getType());
         Assertions.assertNotNull(anime.getStatus());
-        Assertions.assertNotEquals(-1, anime.getEpisodes());
+        Assertions.assertDoesNotThrow(() -> anime.getEpisodes());
         Assertions.assertNotNull(anime.getStartSeason().getSeason());
-        Assertions.assertNotEquals(-1, anime.getStartSeason().getYear());
+        Assertions.assertDoesNotThrow(() -> anime.getStartSeason().getYear());
         Assertions.assertNotNull(anime.getBroadcast().getDayOfWeek());
         Assertions.assertNotNull(anime.getBroadcast().getStartTime());
         Assertions.assertNotNull(anime.getSource());
-        Assertions.assertNotEquals(-1, anime.getAverageEpisodeLength());
+        Assertions.assertDoesNotThrow(() -> anime.getAverageEpisodeLength());
         Assertions.assertNotNull(anime.getRating());
-        Assertions.assertNotEquals(-1, anime.getStudios()[0].getID());
+        Assertions.assertDoesNotThrow(() -> anime.getStudios()[0].getID());
         Assertions.assertNotNull(anime.getStudios()[0].getName());
         Assertions.assertNotNull(anime.getPictures()[0].getMediumURL());
         Assertions.assertNotNull(anime.getPictures()[0].getLargeURL());
@@ -68,7 +68,7 @@ public class TestAnime {
     @Test
     public void testRelatedAnime(){
         final RelatedAnime relatedAnime = anime.getRelatedAnime()[0];
-        Assertions.assertNotEquals(-1, relatedAnime.getAnimePreview().getID());
+        Assertions.assertDoesNotThrow(() -> relatedAnime.getAnimePreview().getID());
         Assertions.assertNotNull(relatedAnime.getRelationType());
         Assertions.assertNotNull(relatedAnime.getRelationTypeFormat());
     }
@@ -76,7 +76,7 @@ public class TestAnime {
     @Test @DisplayName("Anime may not have related Manga") @Disabled
     public void testRelatedManga(){
         final RelatedManga relatedManga = anime.getRelatedManga()[0];
-        Assertions.assertNotEquals(-1, relatedManga.getMangaPreview().getID());
+        Assertions.assertDoesNotThrow(() -> relatedManga.getMangaPreview().getID());
         Assertions.assertNotNull(relatedManga.getRelationType());
         Assertions.assertNotNull(relatedManga.getRelationTypeFormat());
     }
@@ -84,19 +84,19 @@ public class TestAnime {
     @Test
     public void testRecommendations(){
         final AnimeRecommendation recommendation = anime.getRecommendations()[0];
-        Assertions.assertNotEquals(-1, recommendation.getAnimePreview().getID());
-        Assertions.assertNotEquals(-1, recommendation.getRecommendations());
+        Assertions.assertDoesNotThrow(() -> recommendation.getAnimePreview().getID());
+        Assertions.assertDoesNotThrow(recommendation::getRecommendations);
     }
 
     @Test
     public void testStatistics(){
         final AnimeStatistics statistics = anime.getStatistics();
-        Assertions.assertNotEquals(-1, statistics.getCompleted());
-        Assertions.assertNotEquals(-1, statistics.getDropped());
-        Assertions.assertNotEquals(-1, statistics.getOnHold());
-        Assertions.assertNotEquals(-1, statistics.getPlanToWatch());
-        Assertions.assertNotEquals(-1, statistics.getWatching());
-        Assertions.assertNotEquals(-1, statistics.getUserCount());
+        Assertions.assertDoesNotThrow(statistics::getCompleted);
+        Assertions.assertDoesNotThrow(statistics::getDropped);
+        Assertions.assertDoesNotThrow(statistics::getOnHold);
+        Assertions.assertDoesNotThrow(statistics::getPlanToWatch);
+        Assertions.assertDoesNotThrow(statistics::getWatching);
+        Assertions.assertDoesNotThrow(statistics::getUserCount);
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -130,18 +130,18 @@ public class TestAnimeListStatus {
         Assertions.assertEquals(10, status.getScore());
         Assertions.assertEquals(24, status.getWatchedEpisodes());
         Assertions.assertTrue(status.isRewatching());
-        Assertions.assertDoesNotThrow(() -> status.getStartDate().getTime());
-        Assertions.assertDoesNotThrow(status::getStartDateEpochMillis);
-        Assertions.assertDoesNotThrow(() -> status.getFinishDate().getTime());
-        Assertions.assertDoesNotThrow(status::getFinishDateEpochMillis);
+        Assertions.assertNotNull(status.getStartDate());
+        Assertions.assertNotNull(status.getStartDateEpochMillis());
+        Assertions.assertNotNull(status.getFinishDate());
+        Assertions.assertNotNull(status.getFinishDateEpochMillis());
         Assertions.assertEquals(Priority.High, status.getPriority());
         Assertions.assertEquals(0, status.getTimesRewatched());
         Assertions.assertEquals(RewatchValue.VeryHigh, status.getRewatchValue());
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("ignore"));
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("tags"));
         Assertions.assertEquals("ignore comments", status.getComments());
-        Assertions.assertDoesNotThrow(() -> status.getUpdatedAt().getTime());
-        Assertions.assertDoesNotThrow(status::getUpdatedAtEpochMillis);
+        Assertions.assertNotNull(status.getUpdatedAt());
+        Assertions.assertNotNull(status.getUpdatedAtEpochMillis());
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -52,7 +52,7 @@ public class TestAnimeListStatus {
     public void testDelete(){
         mal.deleteAnimeListing(TestProvider.AnimeID);
         Assertions.assertDoesNotThrow(() -> mal.deleteAnimeListing(TestProvider.AnimeID));
-        Assertions.assertThrows(NullPointerException.class, () -> mal.getAnime(TestProvider.AnimeID).getListStatus().getUpdatedAtEpochMillis());
+        Assertions.assertNull(mal.getAnime(TestProvider.AnimeID).getListStatus().getUpdatedAtEpochMillis());
     }
 
     @Test @Order(2)

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -52,7 +52,7 @@ public class TestAnimeListStatus {
     public void testDelete(){
         mal.deleteAnimeListing(TestProvider.AnimeID);
         Assertions.assertDoesNotThrow(() -> mal.deleteAnimeListing(TestProvider.AnimeID));
-        Assertions.assertEquals(-1L, mal.getAnime(TestProvider.AnimeID).getListStatus().getUpdatedAtEpochMillis());
+        Assertions.assertThrows(NullPointerException.class, () -> mal.getAnime(TestProvider.AnimeID).getListStatus().getUpdatedAtEpochMillis());
     }
 
     @Test @Order(2)
@@ -130,18 +130,18 @@ public class TestAnimeListStatus {
         Assertions.assertEquals(10, status.getScore());
         Assertions.assertEquals(24, status.getWatchedEpisodes());
         Assertions.assertTrue(status.isRewatching());
-        Assertions.assertNotEquals(-1, status.getStartDate().getTime());
-        Assertions.assertNotEquals(-1, status.getStartDateEpochMillis());
-        Assertions.assertNotEquals(-1, status.getFinishDate().getTime());
-        Assertions.assertNotEquals(-1, status.getFinishDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> status.getStartDate().getTime());
+        Assertions.assertDoesNotThrow(status::getStartDateEpochMillis);
+        Assertions.assertDoesNotThrow(() -> status.getFinishDate().getTime());
+        Assertions.assertDoesNotThrow(status::getFinishDateEpochMillis);
         Assertions.assertEquals(Priority.High, status.getPriority());
         Assertions.assertEquals(0, status.getTimesRewatched());
         Assertions.assertEquals(RewatchValue.VeryHigh, status.getRewatchValue());
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("ignore"));
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("tags"));
         Assertions.assertEquals("ignore comments", status.getComments());
-        Assertions.assertNotEquals(-1, status.getUpdatedAt().getTime());
-        Assertions.assertNotEquals(-1, status.getUpdatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> status.getUpdatedAt().getTime());
+        Assertions.assertDoesNotThrow(status::getUpdatedAtEpochMillis);
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeRank.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeRank.java
@@ -26,7 +26,7 @@ public class TestAnimeRank {
                 .search();
         final AnimeRanking first = ranking.get(0);
         Assertions.assertEquals(1, first.getRanking());
-        Assertions.assertTrue(first.getPreviousRank() < 1);
+        // Assertions.assertTrue(first.getPreviousRank() < 1); // unable to test
         Assertions.assertEquals(AnimeType.Movie, first.getAnimePreview().getType());
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumCategories.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumCategories.java
@@ -26,7 +26,7 @@ public class TestForumCategories {
     @Test
     public void testBoard(){
         final ForumBoard board = category.getForumBoards()[2];
-        Assertions.assertDoesNotThrow(board::getID);
+        Assertions.assertNotNull(board.getID());
         Assertions.assertNotNull(board.getTitle());
         Assertions.assertNotNull(board.getDescription());
 
@@ -37,7 +37,7 @@ public class TestForumCategories {
     @Test // not all forums have subboards
     public void testSubBoard(){
         final ForumSubBoard subBoard = category.getForumBoards()[2].getSubBoards()[0];
-        Assertions.assertDoesNotThrow(subBoard::getID);
+        Assertions.assertNotNull(subBoard.getID());
         Assertions.assertNotNull(subBoard.getTitle());
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumCategories.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumCategories.java
@@ -26,7 +26,7 @@ public class TestForumCategories {
     @Test
     public void testBoard(){
         final ForumBoard board = category.getForumBoards()[2];
-        Assertions.assertNotEquals(-1, board.getID());
+        Assertions.assertDoesNotThrow(board::getID);
         Assertions.assertNotNull(board.getTitle());
         Assertions.assertNotNull(board.getDescription());
 
@@ -37,7 +37,7 @@ public class TestForumCategories {
     @Test // not all forums have subboards
     public void testSubBoard(){
         final ForumSubBoard subBoard = category.getForumBoards()[2].getSubBoards()[0];
-        Assertions.assertNotEquals(-1, subBoard.getID());
+        Assertions.assertDoesNotThrow(subBoard::getID);
         Assertions.assertNotNull(subBoard.getTitle());
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopicDetail.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopicDetail.java
@@ -29,9 +29,9 @@ public class TestForumTopicDetail {
     @Test
     public void testPosts(){
         final Post post = topic.getPosts()[0];
-        Assertions.assertNotEquals(-1, post.getID());
-        Assertions.assertNotEquals(-1, post.getNumber());
-        Assertions.assertNotEquals(-1, post.getCreatedAt());
+        Assertions.assertDoesNotThrow(post::getID);
+        Assertions.assertDoesNotThrow(post::getNumber);
+        Assertions.assertDoesNotThrow(post::getCreatedAt);
         Assertions.assertNotNull(post.getBody());
         Assertions.assertNotNull(post.getSignature());
         Assertions.assertSame(topic, post.getForumTopic());
@@ -40,15 +40,15 @@ public class TestForumTopicDetail {
     @Test
     public void testPoll(){
         final Poll poll = topic.getPoll();
-        Assertions.assertNotEquals(-1, poll.getID());
+        Assertions.assertDoesNotThrow(poll::getID);
         Assertions.assertNotNull(poll.getQuestion());
-        Assertions.assertFalse(poll.isClosed()); // weak test
+        Assertions.assertFalse(poll.isClosed());
         // options
         {
             final PollOption option = poll.getOptions()[0];
-            Assertions.assertNotEquals(-1, option.getID());
+            Assertions.assertDoesNotThrow(option::getID);
             Assertions.assertNotNull(option.getText());
-            Assertions.assertNotEquals(-1, option.getVotes());
+            Assertions.assertDoesNotThrow(option::getVotes);
             Assertions.assertSame(poll, option.getPoll());
         }
         Assertions.assertSame(topic, poll.getForumTopic());

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopicDetail.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopicDetail.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.*;
 
 public class TestForumTopicDetail {
 
-    @SuppressWarnings("FieldCanBeLocal")
     private static MyAnimeList mal;
     private static ForumTopic topic;
 
@@ -29,9 +28,9 @@ public class TestForumTopicDetail {
     @Test
     public void testPosts(){
         final Post post = topic.getPosts()[0];
-        Assertions.assertDoesNotThrow(post::getID);
-        Assertions.assertDoesNotThrow(post::getNumber);
-        Assertions.assertDoesNotThrow(post::getCreatedAt);
+        Assertions.assertNotNull(post.getID());
+        Assertions.assertNotNull(post.getNumber());
+        Assertions.assertNotNull(post.getCreatedAt());
         Assertions.assertNotNull(post.getBody());
         Assertions.assertNotNull(post.getSignature());
         Assertions.assertSame(topic, post.getForumTopic());
@@ -40,15 +39,15 @@ public class TestForumTopicDetail {
     @Test
     public void testPoll(){
         final Poll poll = topic.getPoll();
-        Assertions.assertDoesNotThrow(poll::getID);
+        Assertions.assertNotNull(poll.getID());
         Assertions.assertNotNull(poll.getQuestion());
         Assertions.assertFalse(poll.isClosed());
         // options
         {
             final PollOption option = poll.getOptions()[0];
-            Assertions.assertDoesNotThrow(option::getID);
+            Assertions.assertNotNull(option.getID());
             Assertions.assertNotNull(option.getText());
-            Assertions.assertDoesNotThrow(option::getVotes);
+            Assertions.assertNotNull(option.getVotes());
             Assertions.assertSame(poll, option.getPoll());
         }
         Assertions.assertSame(topic, poll.getForumTopic());

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopics.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopics.java
@@ -84,10 +84,10 @@ public class TestForumTopics {
         final ForumTopic topic = mal.getForumTopicDetail(481);
         Assertions.assertNotNull(topic.getTitle());
         final Post post = topic.getPosts()[0];
-        Assertions.assertDoesNotThrow(post::getID);
-        Assertions.assertDoesNotThrow(post::getNumber);
-        Assertions.assertDoesNotThrow(post::getCreatedAt);
-        Assertions.assertDoesNotThrow(() -> post.getAuthor().getID());
+        Assertions.assertNotNull(post.getID());
+        Assertions.assertNotNull(post.getNumber());
+        Assertions.assertNotNull(post.getCreatedAt());
+        Assertions.assertNotNull(post.getAuthor().getID());
         Assertions.assertNotNull(post.getAuthor().getName());
         Assertions.assertNotNull(post.getAuthor().getForumAvatarURL());
         // Assertions.assertEquals(post.getAuthor().getID(), post.getAuthor().getUser().getID()); // not yet implemented
@@ -95,26 +95,26 @@ public class TestForumTopics {
         Assertions.assertNotNull(post.getSignature());
         Assertions.assertEquals(topic, post.getForumTopic());
         final Poll poll = topic.getPoll();
-        Assertions.assertDoesNotThrow(poll::getID);
+        Assertions.assertNotNull(poll.getID());
         Assertions.assertNotNull(poll.getQuestion());
         Assertions.assertFalse(poll.isClosed());
-        Assertions.assertDoesNotThrow(() -> poll.getOptions()[0].getID());
+        Assertions.assertNotNull(poll.getOptions()[0].getID());
         Assertions.assertNotNull(poll.getOptions()[1].getText());
-        Assertions.assertDoesNotThrow(() -> poll.getOptions()[0].getVotes());
+        Assertions.assertNotNull(poll.getOptions()[0].getVotes());
         Assertions.assertEquals(topic, poll.getForumTopic());
         Assertions.assertEquals(poll, poll.getOptions()[0].getPoll());
     }
 
     private void testForumTopicDetail(final ForumTopicDetail topic){
-        Assertions.assertDoesNotThrow(topic::getID);
+        Assertions.assertNotNull(topic.getID());
         Assertions.assertNotNull(topic.getTitle());
-        Assertions.assertDoesNotThrow(topic::getCreatedAt);
-        Assertions.assertDoesNotThrow(() -> topic.getCreatedBy().getID());
+        Assertions.assertNotNull(topic.getCreatedAt());
+        Assertions.assertNotNull(topic.getCreatedBy().getID());
         // Assertions.assertEquals(topic.getCreatedBy().getID(), topic.getCreatedBy().getUser().getID()); // not yet implemented
         Assertions.assertNotNull(topic.getCreatedBy().getName());
-        Assertions.assertDoesNotThrow(topic::getPostsCount);
-        Assertions.assertDoesNotThrow(topic::getLastPostCreatedAt);
-        Assertions.assertDoesNotThrow(() -> topic.getLastPostCreatedBy().getID());
+        Assertions.assertNotNull(topic.getPostsCount());
+        Assertions.assertNotNull(topic.getLastPostCreatedAt());
+        Assertions.assertNotNull(topic.getLastPostCreatedBy().getID());
         // Assertions.assertEquals(topic.getLastPostCreatedBy().getID(), topic.getLastPostCreatedBy().getUser().getID()); // not yet implemented
         Assertions.assertNotNull(topic.getLastPostCreatedBy().getName());
         Assertions.assertFalse(topic.isLocked());

--- a/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopics.java
+++ b/src/test/java/com/kttdevelopment/mal4j/ForumTests/TestForumTopics.java
@@ -84,10 +84,10 @@ public class TestForumTopics {
         final ForumTopic topic = mal.getForumTopicDetail(481);
         Assertions.assertNotNull(topic.getTitle());
         final Post post = topic.getPosts()[0];
-        Assertions.assertNotEquals(-1, post.getID());
-        Assertions.assertNotEquals(-1, post.getNumber());
-        Assertions.assertNotEquals(-1, post.getCreatedAt());
-        Assertions.assertNotEquals(-1, post.getAuthor().getID());
+        Assertions.assertDoesNotThrow(post::getID);
+        Assertions.assertDoesNotThrow(post::getNumber);
+        Assertions.assertDoesNotThrow(post::getCreatedAt);
+        Assertions.assertDoesNotThrow(() -> post.getAuthor().getID());
         Assertions.assertNotNull(post.getAuthor().getName());
         Assertions.assertNotNull(post.getAuthor().getForumAvatarURL());
         // Assertions.assertEquals(post.getAuthor().getID(), post.getAuthor().getUser().getID()); // not yet implemented
@@ -95,29 +95,29 @@ public class TestForumTopics {
         Assertions.assertNotNull(post.getSignature());
         Assertions.assertEquals(topic, post.getForumTopic());
         final Poll poll = topic.getPoll();
-        Assertions.assertNotEquals(-1, poll.getID());
+        Assertions.assertDoesNotThrow(poll::getID);
         Assertions.assertNotNull(poll.getQuestion());
-        Assertions.assertFalse(poll.isClosed());  // weak test
-        Assertions.assertNotEquals(-1, poll.getOptions()[0].getID());
+        Assertions.assertFalse(poll.isClosed());
+        Assertions.assertDoesNotThrow(() -> poll.getOptions()[0].getID());
         Assertions.assertNotNull(poll.getOptions()[1].getText());
-        Assertions.assertNotEquals(-1, poll.getOptions()[0].getVotes());
+        Assertions.assertDoesNotThrow(() -> poll.getOptions()[0].getVotes());
         Assertions.assertEquals(topic, poll.getForumTopic());
         Assertions.assertEquals(poll, poll.getOptions()[0].getPoll());
     }
 
     private void testForumTopicDetail(final ForumTopicDetail topic){
-        Assertions.assertNotEquals(-1, topic.getID());
+        Assertions.assertDoesNotThrow(topic::getID);
         Assertions.assertNotNull(topic.getTitle());
-        Assertions.assertNotEquals(-1, topic.getCreatedAt());
-        Assertions.assertNotEquals(-1, topic.getCreatedBy().getID());
+        Assertions.assertDoesNotThrow(topic::getCreatedAt);
+        Assertions.assertDoesNotThrow(() -> topic.getCreatedBy().getID());
         // Assertions.assertEquals(topic.getCreatedBy().getID(), topic.getCreatedBy().getUser().getID()); // not yet implemented
         Assertions.assertNotNull(topic.getCreatedBy().getName());
-        Assertions.assertNotEquals(-1, topic.getPostsCount());
-        Assertions.assertNotEquals(-1, topic.getLastPostCreatedAt());
-        Assertions.assertNotEquals(-1, topic.getLastPostCreatedBy().getID());
+        Assertions.assertDoesNotThrow(topic::getPostsCount);
+        Assertions.assertDoesNotThrow(topic::getLastPostCreatedAt);
+        Assertions.assertDoesNotThrow(() -> topic.getLastPostCreatedBy().getID());
         // Assertions.assertEquals(topic.getLastPostCreatedBy().getID(), topic.getLastPostCreatedBy().getUser().getID()); // not yet implemented
         Assertions.assertNotNull(topic.getLastPostCreatedBy().getName());
-        Assertions.assertFalse(topic.isLocked());  // weak test
+        Assertions.assertFalse(topic.isLocked());
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -30,28 +30,28 @@ public class TestManga {
         Assertions.assertNotNull(manga.getAlternativeTitles().getEnglish());
         Assertions.assertNotNull(manga.getAlternativeTitles().getJapanese());
         Assertions.assertNotNull(manga.getAlternativeTitles().getSynonyms());
-        Assertions.assertNotEquals(-1, manga.getStartDate().getTime());
-        Assertions.assertNotEquals(-1, manga.getStartDateEpochMillis());
-        Assertions.assertNotEquals(-1, manga.getEndDate().getTime());
-        Assertions.assertNotEquals(-1, manga.getEndDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> manga.getStartDate().getTime());
+        Assertions.assertDoesNotThrow(() -> manga.getStartDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> manga.getEndDate().getTime());
+        Assertions.assertDoesNotThrow(() -> manga.getEndDateEpochMillis());
         Assertions.assertNotNull(manga.getSynopsis());
-        Assertions.assertNotEquals(-1, manga.getMeanRating());
-        Assertions.assertNotEquals(-1, manga.getRank());
-        Assertions.assertNotEquals(-1, manga.getPopularity());
-        Assertions.assertNotEquals(-1, manga.getUserListingCount());
-        Assertions.assertNotEquals(-1, manga.getUserScoringCount());
+        Assertions.assertDoesNotThrow(() -> manga.getMeanRating());
+        Assertions.assertDoesNotThrow(() -> manga.getRank());
+        Assertions.assertDoesNotThrow(() -> manga.getPopularity());
+        Assertions.assertDoesNotThrow(() -> manga.getUserListingCount());
+        Assertions.assertDoesNotThrow(() -> manga.getUserScoringCount());
         Assertions.assertNotNull(manga.getNSFW());
-        Assertions.assertNotEquals(-1, manga.getGenres()[0].getId());
+        Assertions.assertDoesNotThrow(() -> manga.getGenres()[0].getId());
         Assertions.assertNotNull(manga.getGenres()[0].getName());
-        Assertions.assertNotEquals(-1, manga.getCreatedAt().getTime());
-        Assertions.assertNotEquals(-1, manga.getCreatedAtEpochMillis());
-        Assertions.assertNotEquals(-1, manga.getUpdatedAt().getTime());
-        Assertions.assertNotEquals(-1, manga.getUpdatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> manga.getCreatedAt().getTime());
+        Assertions.assertDoesNotThrow(() -> manga.getCreatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> manga.getUpdatedAt().getTime());
+        Assertions.assertDoesNotThrow(() -> manga.getUpdatedAtEpochMillis());
         Assertions.assertNotNull(manga.getType());
         Assertions.assertNotNull(manga.getStatus());
-        Assertions.assertNotEquals(-1, manga.getVolumes());
-        Assertions.assertNotEquals(-1, manga.getChapters());
-        Assertions.assertNotEquals(-1, manga.getAuthors()[0].getID());
+        Assertions.assertDoesNotThrow(() -> manga.getVolumes());
+        Assertions.assertDoesNotThrow(() -> manga.getChapters());
+        Assertions.assertDoesNotThrow(() -> manga.getAuthors()[0].getID());
         Assertions.assertNotNull(manga.getAuthors()[0].getFirstName());
         Assertions.assertNotNull(manga.getAuthors()[0].getLastName());
         Assertions.assertNotNull(manga.getAuthors()[0].getRole());
@@ -63,7 +63,7 @@ public class TestManga {
     @Test @DisplayName("Manga may not have related Anime") @Disabled
     public void testRelatedAnime(){
         final RelatedAnime relatedAnime = manga.getRelatedAnime()[0];
-        Assertions.assertNotEquals(-1, relatedAnime.getAnimePreview().getID());
+        Assertions.assertDoesNotThrow(() -> relatedAnime.getAnimePreview().getID());
         Assertions.assertNotNull(relatedAnime.getRelationType());
         Assertions.assertNotNull(relatedAnime.getRelationTypeFormat());
     }
@@ -71,7 +71,7 @@ public class TestManga {
     @Test
     public void testRelatedManga(){
         final RelatedManga relatedManga = manga.getRelatedManga()[0];
-        Assertions.assertNotEquals(-1, relatedManga.getMangaPreview().getID());
+        Assertions.assertDoesNotThrow(() -> relatedManga.getMangaPreview().getID());
         Assertions.assertNotNull(relatedManga.getRelationType());
         Assertions.assertNotNull(relatedManga.getRelationTypeFormat());
     }
@@ -79,19 +79,19 @@ public class TestManga {
     @Test
     public void testRecommendations(){
         final MangaRecommendation recommendation = manga.getRecommendations()[0];
-        Assertions.assertNotEquals(-1, recommendation.getMangaPreview().getID());
-        Assertions.assertNotEquals(-1, recommendation.getRecommendations());
+        Assertions.assertDoesNotThrow(() -> recommendation.getMangaPreview().getID());
+        Assertions.assertDoesNotThrow(recommendation::getRecommendations);
     }
 
     @Test
     public void testStatistics(){
-        Assertions.assertNotEquals(-1, manga.getSerialization()[0].getID());
+        Assertions.assertDoesNotThrow(() -> manga.getSerialization()[0].getID());
         Assertions.assertNotNull(manga.getSerialization()[0].getName());
     }
 
     @Test
     public void testSerialization(){
-        Assertions.assertNotEquals(-1, manga.getSerialization()[0].getID());
+        Assertions.assertDoesNotThrow(() -> manga.getSerialization()[0].getID());
         Assertions.assertNotNull(manga.getSerialization()[0].getName());
     }
     

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -30,28 +30,28 @@ public class TestManga {
         Assertions.assertNotNull(manga.getAlternativeTitles().getEnglish());
         Assertions.assertNotNull(manga.getAlternativeTitles().getJapanese());
         Assertions.assertNotNull(manga.getAlternativeTitles().getSynonyms());
-        Assertions.assertDoesNotThrow(() -> manga.getStartDate().getTime());
-        Assertions.assertDoesNotThrow(() -> manga.getStartDateEpochMillis());
-        Assertions.assertDoesNotThrow(() -> manga.getEndDate().getTime());
-        Assertions.assertDoesNotThrow(() -> manga.getEndDateEpochMillis());
+        Assertions.assertNotNull(manga.getStartDate());
+        Assertions.assertNotNull(manga.getStartDateEpochMillis());
+        Assertions.assertNotNull(manga.getEndDate());
+        Assertions.assertNotNull(manga.getEndDateEpochMillis());
         Assertions.assertNotNull(manga.getSynopsis());
-        Assertions.assertDoesNotThrow(() -> manga.getMeanRating());
-        Assertions.assertDoesNotThrow(() -> manga.getRank());
-        Assertions.assertDoesNotThrow(() -> manga.getPopularity());
-        Assertions.assertDoesNotThrow(() -> manga.getUserListingCount());
-        Assertions.assertDoesNotThrow(() -> manga.getUserScoringCount());
+        Assertions.assertNotNull(manga.getMeanRating());
+        Assertions.assertNotNull(manga.getRank());
+        Assertions.assertNotNull(manga.getPopularity());
+        Assertions.assertNotNull(manga.getUserListingCount());
+        Assertions.assertNotNull(manga.getUserScoringCount());
         Assertions.assertNotNull(manga.getNSFW());
-        Assertions.assertDoesNotThrow(() -> manga.getGenres()[0].getId());
+        Assertions.assertNotNull(manga.getGenres()[0]);
         Assertions.assertNotNull(manga.getGenres()[0].getName());
-        Assertions.assertDoesNotThrow(() -> manga.getCreatedAt().getTime());
-        Assertions.assertDoesNotThrow(() -> manga.getCreatedAtEpochMillis());
-        Assertions.assertDoesNotThrow(() -> manga.getUpdatedAt().getTime());
-        Assertions.assertDoesNotThrow(() -> manga.getUpdatedAtEpochMillis());
+        Assertions.assertNotNull(manga.getCreatedAt());
+        Assertions.assertNotNull(manga.getCreatedAtEpochMillis());
+        Assertions.assertNotNull(manga.getUpdatedAt());
+        Assertions.assertNotNull(manga.getUpdatedAtEpochMillis());
         Assertions.assertNotNull(manga.getType());
         Assertions.assertNotNull(manga.getStatus());
-        Assertions.assertDoesNotThrow(() -> manga.getVolumes());
-        Assertions.assertDoesNotThrow(() -> manga.getChapters());
-        Assertions.assertDoesNotThrow(() -> manga.getAuthors()[0].getID());
+        Assertions.assertNotNull(manga.getVolumes());
+        Assertions.assertNotNull(manga.getChapters());
+        Assertions.assertNotNull(manga.getAuthors()[0].getID());
         Assertions.assertNotNull(manga.getAuthors()[0].getFirstName());
         Assertions.assertNotNull(manga.getAuthors()[0].getLastName());
         Assertions.assertNotNull(manga.getAuthors()[0].getRole());
@@ -63,7 +63,7 @@ public class TestManga {
     @Test @DisplayName("Manga may not have related Anime") @Disabled
     public void testRelatedAnime(){
         final RelatedAnime relatedAnime = manga.getRelatedAnime()[0];
-        Assertions.assertDoesNotThrow(() -> relatedAnime.getAnimePreview().getID());
+        Assertions.assertNotNull(relatedAnime.getAnimePreview().getID());
         Assertions.assertNotNull(relatedAnime.getRelationType());
         Assertions.assertNotNull(relatedAnime.getRelationTypeFormat());
     }
@@ -71,7 +71,7 @@ public class TestManga {
     @Test
     public void testRelatedManga(){
         final RelatedManga relatedManga = manga.getRelatedManga()[0];
-        Assertions.assertDoesNotThrow(() -> relatedManga.getMangaPreview().getID());
+        Assertions.assertNotNull(relatedManga.getMangaPreview().getID());
         Assertions.assertNotNull(relatedManga.getRelationType());
         Assertions.assertNotNull(relatedManga.getRelationTypeFormat());
     }
@@ -79,19 +79,19 @@ public class TestManga {
     @Test
     public void testRecommendations(){
         final MangaRecommendation recommendation = manga.getRecommendations()[0];
-        Assertions.assertDoesNotThrow(() -> recommendation.getMangaPreview().getID());
-        Assertions.assertDoesNotThrow(recommendation::getRecommendations);
+        Assertions.assertNotNull(recommendation.getMangaPreview().getID());
+        Assertions.assertNotNull(recommendation.getRecommendations());
     }
 
     @Test
     public void testStatistics(){
-        Assertions.assertDoesNotThrow(() -> manga.getSerialization()[0].getID());
+        Assertions.assertNotNull(manga.getSerialization()[0].getID());
         Assertions.assertNotNull(manga.getSerialization()[0].getName());
     }
 
     @Test
     public void testSerialization(){
-        Assertions.assertDoesNotThrow(() -> manga.getSerialization()[0].getID());
+        Assertions.assertNotNull(manga.getSerialization()[0].getID());
         Assertions.assertNotNull(manga.getSerialization()[0].getName());
     }
     

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -54,7 +54,7 @@ public class TestMangaListStatus {
     public void testDelete(){
         mal.deleteMangaListing(TestProvider.MangaID);
         Assertions.assertDoesNotThrow(() -> mal.deleteMangaListing(TestProvider.MangaID));
-        Assertions.assertEquals(-1L, mal.getManga(TestProvider.MangaID).getListStatus().getUpdatedAtEpochMillis());
+        Assertions.assertThrows(NullPointerException.class, () -> mal.getManga(TestProvider.MangaID).getListStatus().getUpdatedAtEpochMillis());
     }
 
     @Test @Order(2)
@@ -131,18 +131,18 @@ public class TestMangaListStatus {
         Assertions.assertEquals(0, status.getVolumesRead());
         Assertions.assertEquals(0, status.getChaptersRead());
         Assertions.assertTrue(status.isRereading());
-        Assertions.assertNotEquals(-1, status.getStartDate().getTime());
-        Assertions.assertNotEquals(-1, status.getStartDateEpochMillis());
-        Assertions.assertNotEquals(-1, status.getFinishDate().getTime());
-        Assertions.assertNotEquals(-1, status.getFinishDateEpochMillis());
+        Assertions.assertDoesNotThrow(() -> status.getStartDate().getTime());
+        Assertions.assertDoesNotThrow(status::getStartDateEpochMillis);
+        Assertions.assertDoesNotThrow(() -> status.getFinishDate().getTime());
+        Assertions.assertDoesNotThrow(status::getFinishDateEpochMillis);
         Assertions.assertEquals(Priority.High, status.getPriority());
         Assertions.assertEquals(0, status.getTimesReread());
         Assertions.assertEquals(RereadValue.VeryHigh, status.getRereadValue());
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("ignore"));
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("tags"));
         Assertions.assertEquals("ignore comments", status.getComments());
-        Assertions.assertNotEquals(-1, status.getUpdatedAt().getTime());
-        Assertions.assertNotEquals(-1, status.getUpdatedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> status.getUpdatedAt().getTime());
+        Assertions.assertDoesNotThrow(status::getUpdatedAtEpochMillis);
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -131,18 +131,18 @@ public class TestMangaListStatus {
         Assertions.assertEquals(0, status.getVolumesRead());
         Assertions.assertEquals(0, status.getChaptersRead());
         Assertions.assertTrue(status.isRereading());
-        Assertions.assertDoesNotThrow(() -> status.getStartDate().getTime());
-        Assertions.assertDoesNotThrow(status::getStartDateEpochMillis);
-        Assertions.assertDoesNotThrow(() -> status.getFinishDate().getTime());
-        Assertions.assertDoesNotThrow(status::getFinishDateEpochMillis);
+        Assertions.assertNotNull(status.getStartDate());
+        Assertions.assertNotNull(status.getStartDateEpochMillis());
+        Assertions.assertNotNull(status.getFinishDate());
+        Assertions.assertNotNull(status.getFinishDateEpochMillis());
         Assertions.assertEquals(Priority.High, status.getPriority());
         Assertions.assertEquals(0, status.getTimesReread());
         Assertions.assertEquals(RereadValue.VeryHigh, status.getRereadValue());
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("ignore"));
         Assertions.assertTrue(Arrays.asList(status.getTags()).contains("tags"));
         Assertions.assertEquals("ignore comments", status.getComments());
-        Assertions.assertDoesNotThrow(() -> status.getUpdatedAt().getTime());
-        Assertions.assertDoesNotThrow(status::getUpdatedAtEpochMillis);
+        Assertions.assertNotNull(status.getUpdatedAt());
+        Assertions.assertNotNull(status.getUpdatedAtEpochMillis());
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -54,7 +54,7 @@ public class TestMangaListStatus {
     public void testDelete(){
         mal.deleteMangaListing(TestProvider.MangaID);
         Assertions.assertDoesNotThrow(() -> mal.deleteMangaListing(TestProvider.MangaID));
-        Assertions.assertThrows(NullPointerException.class, () -> mal.getManga(TestProvider.MangaID).getListStatus().getUpdatedAtEpochMillis());
+        Assertions.assertNull(mal.getManga(TestProvider.MangaID).getListStatus().getUpdatedAtEpochMillis());
     }
 
     @Test @Order(2)

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaRank.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaRank.java
@@ -26,7 +26,7 @@ public class TestMangaRank {
                 .search();
         final MangaRanking first = ranking.get(0);
         Assertions.assertEquals(1,first.getRanking());
-        Assertions.assertTrue(first.getPreviousRank() < 1);
+        // Assertions.assertTrue(first.getPreviousRank() < 1); // unable to test
         Assertions.assertEquals(MangaType.Manga, first.getMangaPreview().getType());
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -42,7 +42,7 @@ public abstract class TestProvider {
     static final Path oauth  = new File("src/test/java/resources/oauth.txt").toPath();
 
     public static void init() throws IOException{
-        APICall.debug = false;
+        APICall.debug = true;
         if(oauth.toFile().exists()){ // use existing OAuth
             mal = MyAnimeList.withOAuthToken(Files.readString(oauth));
             if(mal.getAnime(AnimeID, new String[0]) != null)

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -15,7 +15,7 @@ public abstract class TestProvider {
     public static final String AnimeQuery = "さくら荘のペットな彼女";
     public static final long AnimeID = 13759;
 
-     public static final String AltAnimeQuery = "ソードアートオンライン"; // for tests that require additional fields
+    public static final String AltAnimeQuery = "ソードアートオンライン"; // for tests that require additional fields
     public static final long AltAnimeID = 11757; // for tests that require additional fields
 
     public static final String NSFW_AnimeQuery = "いただきっセーエキ";
@@ -42,7 +42,7 @@ public abstract class TestProvider {
     static final Path oauth  = new File("src/test/java/resources/oauth.txt").toPath();
 
     public static void init() throws IOException{
-        APICall.debug = true;
+        APICall.debug = false;
         if(oauth.toFile().exists()){ // use existing OAuth
             mal = MyAnimeList.withOAuthToken(Files.readString(oauth));
             if(mal.getAnime(AnimeID, new String[0]) != null)

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -28,36 +28,36 @@ public class TestUser {
 
     @Test
     public void testMyself(){
-        Assertions.assertNotEquals(-1, user.getID());
+        Assertions.assertDoesNotThrow(user::getID);
         Assertions.assertNotNull(user.getName());
         Assertions.assertNotNull(user.getPictureURL());
         Assertions.assertNotNull(user.getGender());
         Assertions.assertNotNull(user.getLocation());
-        Assertions.assertNotEquals(-1, user.getJoinedAt().getTime());
-        Assertions.assertNotEquals(-1, user.getJoinedAtEpochMillis());
+        Assertions.assertDoesNotThrow(() -> user.getJoinedAt().getTime());
+        Assertions.assertDoesNotThrow(() -> user.getJoinedAtEpochMillis());
         Assertions.assertNotNull(user.getTimeZone());
-        Assertions.assertFalse(user.isSupporter()); // weak test, default is false
+        Assertions.assertThrows(NullPointerException.class, user::isSupporter);
     }
 
     @Test
     public void testStatistics(){
         final UserAnimeStatistics statistics = user.getAnimeStatistics();
-        Assertions.assertNotEquals(-1, statistics.getItemsWatching());
-        Assertions.assertNotEquals(-1, statistics.getItemsCompleted());
-        Assertions.assertNotEquals(-1, statistics.getDaysOnHold());
-        Assertions.assertNotEquals(-1, statistics.getItemsPlanToWatch());
-        Assertions.assertNotEquals(-1, statistics.getItemsDropped());
-        Assertions.assertNotEquals(-1, statistics.getItemsOnHold());
-        Assertions.assertNotEquals(-1, statistics.getItems());
-        Assertions.assertNotEquals(-1, statistics.getDaysWatched());
-        Assertions.assertNotEquals(-1, statistics.getDaysWatching());
-        Assertions.assertNotEquals(-1, statistics.getDaysCompleted());
-        Assertions.assertNotEquals(-1, statistics.getDaysOnHold());
-        Assertions.assertNotEquals(-1, statistics.getDaysDropped());
-        Assertions.assertNotEquals(-1, statistics.getDays());
-        Assertions.assertNotEquals(-1, statistics.getEpisodes());
-        Assertions.assertNotEquals(-1, statistics.getTimesRewatched());
-        Assertions.assertNotEquals(-1, statistics.getMeanScore());
+        Assertions.assertDoesNotThrow(statistics::getItemsWatching);
+        Assertions.assertDoesNotThrow(statistics::getItemsCompleted);
+        Assertions.assertDoesNotThrow(statistics::getDaysOnHold);
+        Assertions.assertDoesNotThrow(statistics::getItemsPlanToWatch);
+        Assertions.assertDoesNotThrow(statistics::getItemsDropped);
+        Assertions.assertDoesNotThrow(statistics::getItemsOnHold);
+        Assertions.assertDoesNotThrow(statistics::getItems);
+        Assertions.assertDoesNotThrow(statistics::getDaysWatched);
+        Assertions.assertDoesNotThrow(statistics::getDaysWatching);
+        Assertions.assertDoesNotThrow(statistics::getDaysCompleted);
+        Assertions.assertDoesNotThrow(statistics::getDaysOnHold);
+        Assertions.assertDoesNotThrow(statistics::getDaysDropped);
+        Assertions.assertDoesNotThrow(statistics::getDays);
+        Assertions.assertDoesNotThrow(statistics::getEpisodes);
+        Assertions.assertDoesNotThrow(statistics::getTimesRewatched);
+        Assertions.assertDoesNotThrow(statistics::getMeanScore);
     }
 
     @Test // test does actually pass

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -65,7 +65,7 @@ public class TestUser {
         Assumptions.assumeTrue(user.getBirthdayEpochMillis() != null, "User might not specify a birthday");
     }
 
-    @Test
+    @Test // false is treated as null
     public void testSupporter(){
         Assumptions.assumeTrue(user.isSupporter() != null);
     }

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -28,13 +28,13 @@ public class TestUser {
 
     @Test
     public void testMyself(){
-        Assertions.assertDoesNotThrow(user::getID);
+        Assertions.assertNotNull(user.getID());
         Assertions.assertNotNull(user.getName());
         Assertions.assertNotNull(user.getPictureURL());
         Assertions.assertNotNull(user.getGender());
         Assertions.assertNotNull(user.getLocation());
-        Assertions.assertDoesNotThrow(() -> user.getJoinedAt().getTime());
-        Assertions.assertDoesNotThrow(() -> user.getJoinedAtEpochMillis());
+        Assertions.assertNotNull(user.getJoinedAt());
+        Assertions.assertNotNull(user.getJoinedAtEpochMillis());
         Assertions.assertNotNull(user.getTimeZone());
         Assertions.assertThrows(NullPointerException.class, user::isSupporter);
     }
@@ -42,28 +42,28 @@ public class TestUser {
     @Test
     public void testStatistics(){
         final UserAnimeStatistics statistics = user.getAnimeStatistics();
-        Assertions.assertDoesNotThrow(statistics::getItemsWatching);
-        Assertions.assertDoesNotThrow(statistics::getItemsCompleted);
-        Assertions.assertDoesNotThrow(statistics::getDaysOnHold);
-        Assertions.assertDoesNotThrow(statistics::getItemsPlanToWatch);
-        Assertions.assertDoesNotThrow(statistics::getItemsDropped);
-        Assertions.assertDoesNotThrow(statistics::getItemsOnHold);
-        Assertions.assertDoesNotThrow(statistics::getItems);
-        Assertions.assertDoesNotThrow(statistics::getDaysWatched);
-        Assertions.assertDoesNotThrow(statistics::getDaysWatching);
-        Assertions.assertDoesNotThrow(statistics::getDaysCompleted);
-        Assertions.assertDoesNotThrow(statistics::getDaysOnHold);
-        Assertions.assertDoesNotThrow(statistics::getDaysDropped);
-        Assertions.assertDoesNotThrow(statistics::getDays);
-        Assertions.assertDoesNotThrow(statistics::getEpisodes);
-        Assertions.assertDoesNotThrow(statistics::getTimesRewatched);
-        Assertions.assertDoesNotThrow(statistics::getMeanScore);
+        Assertions.assertNotNull(statistics.getItemsWatching());
+        Assertions.assertNotNull(statistics.getItemsCompleted());
+        Assertions.assertNotNull(statistics.getDaysOnHold());
+        Assertions.assertNotNull(statistics.getItemsPlanToWatch());
+        Assertions.assertNotNull(statistics.getItemsDropped());
+        Assertions.assertNotNull(statistics.getItemsOnHold());
+        Assertions.assertNotNull(statistics.getItems());
+        Assertions.assertNotNull(statistics.getDaysWatched());
+        Assertions.assertNotNull(statistics.getDaysWatching());
+        Assertions.assertNotNull(statistics.getDaysCompleted());
+        Assertions.assertNotNull(statistics.getDaysOnHold());
+        Assertions.assertNotNull(statistics.getDaysDropped());
+        Assertions.assertNotNull(statistics.getDays());
+        Assertions.assertNotNull(statistics.getEpisodes());
+        Assertions.assertNotNull(statistics.getTimesRewatched());
+        Assertions.assertNotNull(statistics.getMeanScore());
     }
 
     @Test // test does actually pass
     public void testBirthday(){
-        Assumptions.assumeTrue(user.getBirthday().getTime() != -1, "User might not specify a birthday");
-        Assumptions.assumeTrue(user.getBirthdayEpochMillis() != -1, "User might not specify a birthday");
+        Assumptions.assumeTrue(user.getBirthday() != null, "User might not specify a birthday");
+        Assumptions.assumeTrue(user.getBirthdayEpochMillis() != null, "User might not specify a birthday");
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -36,7 +36,6 @@ public class TestUser {
         Assertions.assertNotNull(user.getJoinedAt());
         Assertions.assertNotNull(user.getJoinedAtEpochMillis());
         Assertions.assertNotNull(user.getTimeZone());
-        Assertions.assertThrows(NullPointerException.class, user::isSupporter);
     }
 
     @Test
@@ -64,6 +63,11 @@ public class TestUser {
     public void testBirthday(){
         Assumptions.assumeTrue(user.getBirthday() != null, "User might not specify a birthday");
         Assumptions.assumeTrue(user.getBirthdayEpochMillis() != null, "User might not specify a birthday");
+    }
+
+    @Test
+    public void testSupporter(){
+        Assumptions.assumeTrue(user.isSupporter() != null);
     }
 
 }


### PR DESCRIPTION
#  _Major Update_
Previously primitive fields would return default values, -1, false; this would make it difficult to tell which fields were actually null and which fields actually had those values.

All objects now return object type instead of primitives to handle nulls.
```
int → Integer
float → Float
long → Long
boolean → Boolean
```
Null long will now also return null Date.

- Closes #62
- Fixes issue where poll closed didn't work
- Fixed issue where poll option ID was always 0