### PR TITLE
Add Opening/Ending to Anime

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ MangaListStatus status =
 
 ### Structured Objects
 
-**All** information provided in the [MyAnimeList API](https://myanimelist.net/apiconfig/references/api/v2) including Anime, Manga, forums, genres, pictures, and statistics is accessible in this library. Effortlessly retrive any and all information you need.
+**All** information provided in the [MyAnimeList API](https://myanimelist.net/apiconfig/references/api/v2) including Anime, Manga, forums, genres, pictures, statistics, and even some *undocumented* fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 ```java
 MyAnimeList mal = MyAnimeList.withOAuthToken("");
@@ -101,6 +101,7 @@ String ja = anime.getAlternativeTitles().getJapanese();
 Genre[] genres = anime.getGenres();
 RelatedAnime[] relatedAnime = anime.getRelatedAnime();
 AnimeRecommendation[] recs = anime.getRecommendations();
+OpeningTheme[] op = anime.getOpeningThemes();
 ```
 
 ---

--- a/readme.bbcode
+++ b/readme.bbcode
@@ -40,7 +40,7 @@ MangaListStatus status =
 [/code]
 
 [size=150]List Modification[/size]
-[b]All[/b] information provided in the MyAnimeList API including Anime, Manga, forums, genres, pictures, and statistics is accessible in this library. Effortlessly retrive any and all information you need.
+[b]All[/b] information provided in the [MyAnimeList API](https://myanimelist.net/apiconfig/references/api/v2) including Anime, Manga, forums, genres, pictures, statistics, and even some [i]undocumented[/i] fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 [code]
 MyAnimeList mal = MyAnimeList.withOAuthToken("");
@@ -50,6 +50,7 @@ String ja = anime.getAlternativeTitles().getJapanese();
 Genre[] genres = anime.getGenres();
 RelatedAnime[] relatedAnime = anime.getRelatedAnime();
 AnimeRecommendation[] recs = anime.getRecommendations();
+OpeningTheme[] op = anime.getOpeningThemes();
 [/code]
 
 [center][size=200][url=https://github.com/Katsute/Mal4J]View on GitHub[/url][/size][/center]

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
@@ -49,7 +49,7 @@ public abstract class MyAnimeList {
      * Returns all possible Anime fields.
      */
     @SuppressWarnings("SpellCheckingInspection")
-    public static final String ALL_ANIME_FIELDS = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_episodes,start_season,broadcast,source,average_episode_duration,rating,pictures,background,related_anime,related_manga,recommendations,studios,statistics,my_list_status{start_date,finish_date,priority,num_times_rewatched,rewatch_value,tags,comments},list_status{start_date,finish_date,priority,num_times_rewatched,rewatch_value,tags,comments}";
+    public static final String ALL_ANIME_FIELDS = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_episodes,start_season,broadcast,source,average_episode_duration,rating,pictures,background,related_anime,related_manga,recommendations,studios,statistics,my_list_status{start_date,finish_date,priority,num_times_rewatched,rewatch_value,tags,comments},list_status{start_date,finish_date,priority,num_times_rewatched,rewatch_value,tags,comments},opening_themes,ending_themes";
 
     /**
      * Returns all possible Manga fields.

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -185,6 +185,72 @@ abstract class MyAnimeListAPIResponseMapping {
             };
         }
 
+        static OpeningTheme asOpeningTheme(final MyAnimeList mal, final JsonObject schema, final com.kttdevelopment.mal4j.anime.Anime anime){
+            return new OpeningTheme() {
+
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
+                private final String text   = requireNonNull(() -> schema.getString("text"));
+
+                // API methods
+
+                @Override
+                public final Long getID(){
+                    return id;
+                }
+
+                @Override
+                public final String getText(){
+                    return text;
+                }
+
+                // additional methods
+
+                @Override
+                public final com.kttdevelopment.mal4j.anime.Anime getAnime(){
+                    return anime;
+                }
+
+                @Override
+                public String toString(){
+                    return AutomatedToString(this);
+                }
+
+            };
+        }
+
+        static EndingTheme asEndingTheme(final MyAnimeList mal, final JsonObject schema, final com.kttdevelopment.mal4j.anime.Anime anime){
+            return new EndingTheme() {
+
+                private final Long id       = requireNonNull(() -> schema.getLong("id"));
+                private final String text   = requireNonNull(() -> schema.getString("text"));
+
+                // API methods
+
+                @Override
+                public final Long getID(){
+                    return id;
+                }
+
+                @Override
+                public final String getText(){
+                    return text;
+                }
+
+                // additional methods
+
+                @Override
+                public final com.kttdevelopment.mal4j.anime.Anime getAnime(){
+                    return anime;
+                }
+
+                @Override
+                public String toString(){
+                    return AutomatedToString(this);
+                }
+
+            };
+        }
+
         static com.kttdevelopment.mal4j.anime.Anime asAnime(final MyAnimeList mal, final JsonObject schema){
             return new com.kttdevelopment.mal4j.anime.Anime() {
 
@@ -227,6 +293,10 @@ abstract class MyAnimeListAPIResponseMapping {
                                                     = requireNonNull(() -> adaptList(schema.getJsonArray("recommendations"), r -> asAnimeRecommendation(mal, r), AnimeRecommendation.class));
                 private final AnimeStatistics statistics
                                                     = requireNonNull(() -> asAnimeStatistics(mal, schema.getJsonObject("statistics")));
+                private final OpeningTheme[] openingThemes
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("opening_themes"), o -> asOpeningTheme(mal, o, this), OpeningTheme.class));
+                private final EndingTheme[] endingThemes
+                                                    = requireNonNull(() -> adaptList(schema.getJsonArray("ending_themes"), o -> asEndingTheme(mal, o, this), EndingTheme.class));
 
                 // API methods
 
@@ -398,6 +468,16 @@ abstract class MyAnimeListAPIResponseMapping {
                 @Override
                 public final AnimeStatistics getStatistics() {
                     return statistics;
+                }
+
+                @Override
+                public final OpeningTheme[] getOpeningThemes(){
+                    return openingThemes;
+                }
+
+                @Override
+                public final EndingTheme[] getEndingThemes(){
+                    return endingThemes;
                 }
 
                 // additional methods

--- a/src/main/java/com/kttdevelopment/mal4j/anime/Anime.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/Anime.java
@@ -35,6 +35,26 @@ import com.kttdevelopment.mal4j.property.FullMediaItem;
  */
 public abstract class Anime extends AnimePreview implements FullMediaItem<AnimeType,AnimeAirStatus,AnimeListStatus,AnimeRecommendation,AnimeStatistics> {
 
+    /**
+     * Returns the opening themes.
+     *
+     * @return opening themes
+     *
+     * @see OpeningTheme
+     * @since 1.0.0
+     */
+    public abstract OpeningTheme[] getOpeningThemes();
+
+    /**
+     * Returns the ending themes.
+     *
+     * @return ending themes
+     *
+     * @see EndingTheme
+     * @since 1.0.0
+     */
+    public abstract EndingTheme[] getEndingThemes();
+
     // additional methods
 
     @Override

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/EndingTheme.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/EndingTheme.java
@@ -1,0 +1,16 @@
+package com.kttdevelopment.mal4j.anime.property;
+
+import com.kttdevelopment.mal4j.anime.Anime;
+
+/**
+ * Represents an Anime ending.
+ *
+ * @see Theme
+ * @see Anime#getEndingThemes()
+ * @since 1.0.0
+ * @version 1.0.0
+ * @author Ktt Development
+ */
+public abstract class EndingTheme extends Theme {
+
+}

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/OpeningTheme.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/OpeningTheme.java
@@ -1,0 +1,16 @@
+package com.kttdevelopment.mal4j.anime.property;
+
+import com.kttdevelopment.mal4j.anime.Anime;
+
+/**
+ * Represents an Anime opening.
+ *
+ * @see Theme
+ * @see Anime#getOpeningThemes()
+ * @since 1.0.0
+ * @version 1.0.0
+ * @author Ktt Development
+ */
+public abstract class OpeningTheme extends Theme {
+
+}

--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/Theme.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/Theme.java
@@ -1,0 +1,26 @@
+package com.kttdevelopment.mal4j.anime.property;
+
+import com.kttdevelopment.mal4j.anime.Anime;
+import com.kttdevelopment.mal4j.property.ID;
+
+/**
+ * Represents an Anime op/ed.
+ *
+ * @see Anime#getOpeningThemes()
+ * @see Anime#getEndingThemes()
+ * @since 1.0.0
+ * @version 1.0.0
+ * @author Ktt Development
+ */
+public abstract class Theme implements AnimeRetrievable, ID {
+
+    /**
+     * Returns the display name for the op/ed.
+     *
+     * @return display name
+     *
+     * @since 1.0.0
+     */
+    public abstract String getText();
+
+}

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -61,6 +61,12 @@ public class TestAnime {
         Assertions.assertNotNull(anime.getPictures()[0].getMediumURL());
         Assertions.assertNotNull(anime.getPictures()[0].getLargeURL());
         Assertions.assertNotNull(anime.getBackground());
+        Assertions.assertNotNull(anime.getOpeningThemes()[0].getID());
+        Assertions.assertNotNull(anime.getOpeningThemes()[0].getText());
+        Assertions.assertSame(anime.getOpeningThemes()[0].getAnime(), anime);
+        Assertions.assertNotNull(anime.getEndingThemes()[0].getID());
+        Assertions.assertNotNull(anime.getEndingThemes()[0].getText());
+        Assertions.assertSame(anime.getEndingThemes()[0].getAnime(), anime);
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -90,8 +90,7 @@ public class TestAnimeListStatus {
                 break;
             else
                 status = null;
-        if(status == null)
-            Assertions.fail();
+        Assertions.assertNotNull(status);
 
         testStatus(status);
     }
@@ -111,8 +110,7 @@ public class TestAnimeListStatus {
                 break;
             else
                 status = null;
-        if(status == null)
-            Assertions.fail();
+        Assertions.assertNotNull(status);
 
         testStatus(status);
     }

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -92,8 +92,7 @@ public class TestMangaListStatus {
                 break;
             else
                 status = null;
-        if(status == null)
-            Assertions.fail();
+        Assertions.assertNotNull(status);
 
         testStatus(status);
     }
@@ -113,8 +112,7 @@ public class TestMangaListStatus {
                 break;
             else
                 status = null;
-        if(status == null)
-            Assertions.fail();
+        Assertions.assertNotNull(status);
 
         testStatus(status);
     }

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -45,7 +45,7 @@ public abstract class TestProvider {
         APICall.debug = false;
         if(oauth.toFile().exists()){ // use existing OAuth
             mal = MyAnimeList.withOAuthToken(Files.readString(oauth));
-            if(mal.getAnime(AnimeID, new String[0]) != null)
+            if(mal.getAnime(AnimeID, MyAnimeList.NO_FIELDS) != null)
                 return;
         }
         testRequireClientID(); // prevent CI from executing tests


### PR DESCRIPTION
- Closes #88 

Adds op/eds to Anime.

Op/ed name returns only text because the format used is not consistent across all Anime.