### PR TITLE
Fix critical issue where UserRetrievable could not be accessed

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module Mal4J {
     exports com.kttdevelopment.mal4j.property;
     exports com.kttdevelopment.mal4j.query;
     exports com.kttdevelopment.mal4j.user;
+    exports com.kttdevelopment.mal4j.user.property;
     exports com.kttdevelopment.mal4j;
 
 }


### PR DESCRIPTION
Fixes missing export statement for `User.Property`