### PR TITLE
Fixed Light novels having unknown type.

### DIFF
--- a/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
@@ -29,14 +29,19 @@ package com.kttdevelopment.mal4j.manga.property;
 @SuppressWarnings("SpellCheckingInspection")
 public enum MangaType {
 
-    Unknown ("unknown"),
-    Manga   ("manga"),
-    Novel   ("novel"),
-    OneShot ("one_shot"),
-    Doujin  ("doujinshi"),
-    Manhwa  ("manhwa"),
-    Manhua  ("manhua"),
-    OEL     ("oel");
+    Unknown     ("unknown"),
+    Manga       ("manga"),
+    /**
+     * @deprecated use {@link #LightNovel}
+     */
+    @Deprecated
+    Novel       ("novel"),
+    LightNovel  ("light_novel"),
+    OneShot     ("one_shot"),
+    Doujin      ("doujinshi"),
+    Manhwa      ("manhwa"),
+    Manhua      ("manhua"),
+    OEL         ("oel");
 
     private final String field;
 

--- a/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
@@ -23,7 +23,7 @@ package com.kttdevelopment.mal4j.manga.property;
  *
  * @see com.kttdevelopment.mal4j.manga.MangaPreview#getType()
  * @since 1.0.0
- * @version 1.0.0
+ * @version 1.1.0
  * @author Ktt Development
  */
 @SuppressWarnings("SpellCheckingInspection")


### PR DESCRIPTION
Light novels should now correctly return `LightNovel` as the type (#126).

This pull deprecates the `Novel` enum as it is not used by MyAnimeList, it will be removed in a later release.