### PR TITLE
Retrieve User Anime/Manga listings from User object.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>mal4j</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <profiles>
         <profile>

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -26,8 +26,7 @@ import com.kttdevelopment.mal4j.forum.property.*;
 import com.kttdevelopment.mal4j.manga.*;
 import com.kttdevelopment.mal4j.manga.property.*;
 import com.kttdevelopment.mal4j.property.*;
-import com.kttdevelopment.mal4j.query.AnimeListUpdate;
-import com.kttdevelopment.mal4j.query.MangaListUpdate;
+import com.kttdevelopment.mal4j.query.*;
 import com.kttdevelopment.mal4j.user.UserAnimeStatistics;
 
 import java.lang.reflect.Array;
@@ -2309,6 +2308,16 @@ abstract class MyAnimeListAPIResponseMapping {
                 }
 
                 // additional methods
+
+                @Override
+                public final UserAnimeListQuery getUserAnimeListing(){
+                    return mal.getUserAnimeListing(name);
+                }
+
+                @Override
+                public final UserMangaListQuery getUserMangaListing(){
+                    return mal.getUserMangaListing(name);
+                }
 
                 @Override
                 public final String toString(){

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -676,12 +676,9 @@ final class MyAnimeListImpl extends MyAnimeList{
         return getUser(username, (String[]) null);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     public final User getUser(final String username, final String... fields){
         Objects.requireNonNull(username, "Username cannot be null");
-        if(!username.equals("@me"))
-            throw new UnsupportedOperationException("The MyAnimeList API currently only supports user @me");
         return asUser(this,
         handleResponse(
             () -> service.getUser(

--- a/src/main/java/com/kttdevelopment/mal4j/user/User.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/User.java
@@ -34,7 +34,7 @@ import java.util.Date;
  * @see MyAnimeList#getUser(String)
  * @see MyAnimeList#getUser(String, String...)
  * @since 1.0.0
- * @version 1.0.0
+ * @version 1.2.0
  * @author Ktt Development
  */
 public abstract class User implements IDN {

--- a/src/main/java/com/kttdevelopment/mal4j/user/User.java
+++ b/src/main/java/com/kttdevelopment/mal4j/user/User.java
@@ -20,6 +20,8 @@ package com.kttdevelopment.mal4j.user;
 
 import com.kttdevelopment.mal4j.MyAnimeList;
 import com.kttdevelopment.mal4j.property.IDN;
+import com.kttdevelopment.mal4j.query.UserAnimeListQuery;
+import com.kttdevelopment.mal4j.query.UserMangaListQuery;
 
 import java.util.Date;
 
@@ -120,5 +122,29 @@ public abstract class User implements IDN {
      * @since 1.0.0
      */
     public abstract Boolean isSupporter();
+
+    /**
+     * Returns user Anime list.
+     *
+     * @return Anime listing
+     *
+     * @see UserAnimeListQuery
+     * @see MyAnimeList#getUserAnimeListing()
+     * @see MyAnimeList#getUserAnimeListing(String)
+     * @since 1.2.0
+     */
+    public abstract UserAnimeListQuery getUserAnimeListing();
+
+    /**
+     * Returns user Manga list.
+     *
+     * @return Manga listing
+     *
+     * @see UserMangaListQuery
+     * @see MyAnimeList#getUserMangaListing()
+     * @see MyAnimeList#getUserMangaListing(String)
+     * @since 1.2.0
+     */
+    public abstract UserMangaListQuery getUserMangaListing();
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -56,9 +56,4 @@ public class TestMyAnimeList {
         Assertions.assertThrows(NullPointerException.class, () -> mal.getUser(null));
     }
 
-    @Test
-    public void testNonAtMeUser(){
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> mal.getUser("null"));
-    }
-
 }

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -64,4 +64,10 @@ public class TestUser {
         Assumptions.assumeTrue(user.getBirthday() != null, "User might not specify a birthday");
     }
 
+    @Test
+    public void testAnimeMangaListing(){
+        Assertions.assertNotEquals(0, user.getUserAnimeListing().withNoFields().search().size());
+        Assertions.assertNotEquals(0, user.getUserMangaListing().withNoFields().search().size());
+    }
+
 }

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -17,14 +17,6 @@ public class TestUser {
         user = mal.getMyself(Fields.user);
     }
 
-    @SuppressWarnings("SpellCheckingInspection")
-    @Test @DisplayName("testUser() - not currently allowed by API")
-    public void testUser(){
-        Assertions.assertThrows(UnsupportedOperationException.class, () ->
-            Assertions.assertEquals(8316239, mal.getUser("KatsuteDev", Fields.NO_FIELDS).getID())
-        );
-    }
-
     @Test
     public void testMyself(){
         Assertions.assertNotNull(user.getID());


### PR DESCRIPTION
> Closes #125 

Developers will now be able to access user Anime/Manga list statuses from the user object.
This update also shifts username enforcement to the server.