### PR TITLE
Fix Genre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>mal4j</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0</version>
 
     <profiles>
         <profile>

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAPIResponseMapping.java
@@ -290,7 +290,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
                 private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
-                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
+                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asAnimeGenre(g.getInt("id")), Genre.class));
                 private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final AnimeType type        = requireNonNull(() -> AnimeType.asEnum(schema.getString("media_type")));
@@ -810,7 +810,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
                 private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
-                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
+                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asAnimeGenre(g.getInt("id")), Genre.class));
                 private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final AnimeType type        = requireNonNull(() -> AnimeType.asEnum(schema.getString("media_type")));
@@ -1812,7 +1812,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
                 private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
-                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
+                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asMangaGenre(g.getInt("id")), Genre.class));
                 private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final MangaType type        = requireNonNull(() -> MangaType.asEnum(schema.getString("media_type")));
@@ -2300,7 +2300,7 @@ abstract class MyAnimeListAPIResponseMapping {
                 private final Integer usersListing  = requireNonNull(() -> schema.getInt("num_list_users"));
                 private final Integer usersScoring  = requireNonNull(() -> schema.getInt("num_scoring_users"));
                 private final NSFW nsfw             = requireNonNull(() -> NSFW.asEnum(schema.getString("nsfw")));
-                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asEnum(g.getInt("id")), Genre.class));
+                private final Genre[] genres        = requireNonNull(() -> adaptList(schema.getJsonArray("genres"), g -> Genre.asMangaGenre(g.getInt("id")), Genre.class));
                 private final Long createdAt        = requireNonNull(() -> parseISO8601(schema.getString("created_at")));
                 private final Long updatedAt        = requireNonNull(() -> parseISO8601(schema.getString("updated_at")));
                 private final MangaType type        = requireNonNull(() -> MangaType.asEnum(schema.getString("media_type")));

--- a/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
@@ -19,75 +19,150 @@
 package com.kttdevelopment.mal4j.property;
 
 /**
- * Represents a Genre.
- *
+ * Represents a Genre. Genre IDs are different for Anime and Manga.
+ *.
  * @since 1.0.0
- * @version 1.0.0
+ * @version 2.1.0
  * @author Ktt Development
  */
 @SuppressWarnings("SpellCheckingInspection")
 public enum Genre {
 
-    Adventure       (1  , "Adventure"),
-    Action          (2  , "Action"),
-    Cars            (3  , "Cars"),
-    Comedy          (4  , "Comedy"),
-    Dementia        (5  , "Dementia"),
-    Demons          (6  , "Demons"),
-    Drama           (7  , "Drama"),
-    Ecchi           (8  , "Ecchi"),
-    Fantasy         (9  , "Fantasy"),
-    Game            (10 , "Game"),
-    Harem           (11 , "Harem"),
-    Historical      (12 , "Historical"),
-    Horror          (13 , "Horror"),
-    Josei           (14 , "Josei"),
-    Kids            (15 , "Kids"),
-    Magic           (16 , "Magic"),
-    MartialArts     (17 , "Martial Arts"),
-    Mecha           (18 , "Mecha"),
-    Military        (19 , "Military"),
-    Music           (20 , "Music"),
-    Mystery         (21 , "Mystery"),
-    Parody          (22 , "Parody"),
-    Police          (23 , "Police"),
-    Psychological   (24 , "Psychological"),
-    Romance         (25 , "Romance"),
-    Samurai         (26 , "Samurai"),
-    School          (27 , "School"),
-    SciFi           (28 , "Sci-Fi"),
-    Seinen          (29 , "Seinen"),
-    Shoujo          (30 , "Shoujo"),
-    ShoujoAi        (31 , "Shoujo Ai"),
-    Shounen         (32 , "Shounen"),
-    ShounenAi       (33 , "Shounen Ai"),
-    SliceOfLife     (34 , "Slice of Life"),
-    Space           (35 , "Space"),
-    Sports          (36 , "Sports"),
-    SuperPower      (37 , "Super Power"),
-    Supernatural    (38 , "Supernatural"),
-    Thriller        (39 , "Thriller"),
-    Vampire         (40 , "Vampire");
+    Adventure       (2  , 2  , "Adventure"),
+    Action          (1  , 1  , "Action"),
+    Cars            (3  , 3  , "Cars"),
+    Comedy          (4  , 4  , "Comedy"),
+    Dementia        (5  , 5  , "Dementia"),
+    Demons          (6  , 6  , "Demons"),
+    Drama           (8  , 8  , "Drama"),
+    Doujinshi       (-1 , 43 , "Doujinshi"),
+    Ecchi           (9  , 9  , "Ecchi"),
+    Fantasy         (10 , 10 , "Fantasy"),
+    Game            (11 , 11 , "Game"),
+    GenderBender    (-1 , 44 , "Gender Bender"),
+    Harem           (35 , 35 , "Harem"),
+    Hentai          (12 , 12 , "Hentai"),
+    Historical      (13 , 13 , "Historical"),
+    Horror          (14 , 14 , "Horror"),
+    Josei           (43 , 42 , "Josei"),
+    Kids            (15 , 15 , "Kids"),
+    Magic           (16 , 16 , "Magic"),
+    MartialArts     (17 , 17 , "Martial Arts"),
+    Mecha           (18 , 18 , "Mecha"),
+    Military        (38 , 38 , "Military"),
+    Music           (19 , 19 , "Music"),
+    Mystery         (7  , 7  , "Mystery"),
+    Parody          (20 , 20 , "Parody"),
+    Police          (39 , 39 , "Police"),
+    Psychological   (40 , 40 , "Psychological"),
+    Romance         (22 , 22 , "Romance"),
+    Samurai         (21 , 21 , "Samurai"),
+    School          (23 , 23 , "School"),
+    SciFi           (24 , 24 , "Sci-Fi"),
+    Seinen          (42 , 41 , "Seinen"),
+    Shoujo          (25 , 25 , "Shoujo"),
+    ShoujoAi        (26 , 26 , "Shoujo Ai"),
+    Shounen         (27 , 27 , "Shounen"),
+    ShounenAi       (28 , 28 , "Shounen Ai"),
+    SliceOfLife     (36 , 36 , "Slice of Life"),
+    Space           (29 , 29 , "Space"),
+    Sports          (30 , 30 , "Sports"),
+    SuperPower      (31 , 31 , "Super Power"),
+    Supernatural    (37 , 37 , "Supernatural"),
+    Thriller        (41 , 45 , "Thriller"),
+    Vampire         (32 , 32 , "Vampire"),
+    Yaoi            (33 , 33 , "Yaoi"),
+    Yuri            (34 , 34 , "Yuri");
 
-    private final int id;
+    private final int animeGenreID, mangaGenreID;
     private final String name;
 
-    Genre(final int id, final String name){
-        this.id   = id;
-        this.name = name;
+    Genre(final int animeGenreID, final int mangaId, final String name){
+        this.animeGenreID = animeGenreID;
+        this.mangaGenreID = mangaId;
+        this.name    = name;
     }
 
+    /**
+     * @deprecated Use {@link #getAnimeGenreID()} or {@link #getMangaGenreId()}
+     * @return id
+     */
+    @Deprecated
     public final int getId(){
-        return id;
+        return animeGenreID;
+    }
+
+    /**
+     * Returns the genre ID for Anime.
+     *
+     * @throws UnsupportedOperationException if there is no ID associated with this genre for Anime
+     * @return Anime genre ID
+     *
+     * @since 2.1.0
+     */
+    public final int getAnimeGenreID(){
+        if(animeGenreID == -1)
+            throw new UnsupportedOperationException("There is no Anime genre ID for this genre. Try getMangaGenreID()");
+        return animeGenreID;
+    }
+
+    /**
+     * Returns the genre ID for Manga.
+     *
+     * @throws UnsupportedOperationException if there is no ID associated with this genre for Manga
+     * @return Manga genre ID
+     *
+     * @since 2.1.0
+     */
+    public final int getMangaGenreId(){
+        if(mangaGenreID == -1)
+            throw new UnsupportedOperationException("There is no Manga genre ID for this genre. Try getAnimeGenreID()");
+        return mangaGenreID;
     }
 
     public final String getName(){
         return name;
     }
 
+    /**
+     * @deprecated Use {@link #asAnimeGenre(int)} or {@link #asMangaGenre(int)}
+     * @param id id
+     * @return genre
+     */
+    @Deprecated
     public static Genre asEnum(final int id){
         for(final Genre value : values())
-            if(value.id == id)
+            if(value.animeGenreID == id)
+                return value;
+        return null;
+    }
+
+    /**
+     * Returns the Anime genre associated with the ID.
+     *
+     * @param id genre ID
+     * @return genre enum
+     *
+     * @since 2.1.0
+     */
+    public static Genre asAnimeGenre(final int id){
+        for(final Genre value : values())
+            if(value.animeGenreID == id)
+                return value;
+        return null;
+    }
+
+    /**
+     * Returns the Manga genre associated with the ID.
+     *
+     * @param id genre ID
+     * @return genre enum
+     *
+     * @since 2.1.0
+     */
+    public static Genre asMangaGenre(final int id){
+        for(final Genre value : values())
+            if(value.mangaGenreID == id)
                 return value;
         return null;
     }

--- a/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
@@ -84,7 +84,7 @@ public enum Genre {
     }
 
     /**
-     * @deprecated Use {@link #getAnimeGenreID()} or {@link #getMangaGenreId()}
+     * @deprecated Use {@link #getAnimeGenreID()} or {@link #getMangaGenreID()}
      * @return id
      */
     @Deprecated
@@ -114,7 +114,7 @@ public enum Genre {
      *
      * @since 2.1.0
      */
-    public final int getMangaGenreId(){
+    public final int getMangaGenreID(){
         if(mangaGenreID == -1)
             throw new UnsupportedOperationException("There is no Manga genre ID for this genre. Try getAnimeGenreID()");
         return mangaGenreID;

--- a/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
+++ b/src/main/java/com/kttdevelopment/mal4j/property/Genre.java
@@ -20,7 +20,7 @@ package com.kttdevelopment.mal4j.property;
 
 /**
  * Represents a Genre. Genre IDs are different for Anime and Manga.
- *.
+ *
  * @since 1.0.0
  * @version 2.1.0
  * @author Ktt Development

--- a/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
@@ -1,0 +1,65 @@
+package com.kttdevelopment.mal4j;
+
+import com.kttdevelopment.mal4j.property.Genre;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TestGenre {
+
+    // \Qlabel_for_genre-\E(\d+)">([a-zA-Z]+)\Q</label>\E$
+    private static final Pattern label = Pattern.compile("\\Qlabel_for_genre-\\E(\\d+)\">([a-zA-Z]+)\\Q</label>\\E");
+
+    @Test
+    public void testAnimeGenres() throws IOException{
+        final URL url = new URL("https://myanimelist.net/anime.php");
+
+        final BufferedReader IN = new BufferedReader(new InputStreamReader(url.openStream()));
+        final StringBuilder OUT = new StringBuilder();
+        String ln;
+        while((ln = IN.readLine()) != null)
+            OUT.append(ln);
+        IN.close();
+
+        final String raw = OUT.toString();
+
+        final Matcher matcher = label.matcher(raw);
+        while(matcher.find()){
+            Assertions.assertEquals(
+                Integer.parseInt(matcher.group(1)), // expected ID
+                Objects.requireNonNull(Genre.asEnum(matcher.group(2))).getAnimeGenreID(), //actual id
+                "MyAnimeList Anime Genre ID doesn't match Genre enum"
+            );
+        }
+    }
+
+    @Test
+    public void testMangaGenres() throws IOException{
+        final URL url = new URL("https://myanimelist.net/manga.php");
+
+        final BufferedReader IN = new BufferedReader(new InputStreamReader(url.openStream()));
+        final StringBuilder OUT = new StringBuilder();
+        String ln;
+        while((ln = IN.readLine()) != null)
+            OUT.append(ln);
+        IN.close();
+
+        final String raw = OUT.toString();
+
+        final Matcher matcher = label.matcher(raw);
+        while(matcher.find()){
+            Assertions.assertEquals(
+                Integer.parseInt(matcher.group(1)), // expected ID
+                Objects.requireNonNull(Genre.asEnum(matcher.group(2))).getMangaGenreId(), //actual id
+                "MyAnimeList Manga Genre ID doesn't match Genre enum"
+            );
+        }
+    }
+
+}

--- a/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -56,7 +55,7 @@ public class TestGenre {
         while(matcher.find()){
             Assertions.assertEquals(
                 Integer.parseInt(matcher.group(1)), // expected ID
-                Objects.requireNonNull(Genre.asEnum(matcher.group(2))).getMangaGenreId(), //actual id
+                Objects.requireNonNull(Genre.asEnum(matcher.group(2))).getMangaGenreID(), //actual id
                 "MyAnimeList Manga Genre ID doesn't match Genre enum"
             );
         }

--- a/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestGenre.java
@@ -1,8 +1,7 @@
 package com.kttdevelopment.mal4j;
 
 import com.kttdevelopment.mal4j.property.Genre;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.*;
 import java.net.URL;
@@ -14,6 +13,11 @@ public class TestGenre {
 
     // \Qlabel_for_genre-\E(\d+)">([a-zA-Z]+)\Q</label>\E$
     private static final Pattern label = Pattern.compile("\\Qlabel_for_genre-\\E(\\d+)\">([a-zA-Z]+)\\Q</label>\\E");
+
+    @BeforeAll
+    public static void beforeAll(){
+        Assumptions.assumeTrue(System.getProperty("java.version").charAt(0) != '9'); // SSL issue; OK to skip since other tests validate
+    }
 
     @Test
     public void testAnimeGenres() throws IOException{


### PR DESCRIPTION
### ⚠ DEVELOPER NOTICE:
- `Genre#asEnum` is now deprecated. Use `Genre#asAnimeGenre` or `Genre#asMangaGenre`.
- `Genre#getId` is now deprecated. Use `Genre#getAnimeGenreID` or `Genre#getMangaGenreID`.
- Anime/Manga genres are not sorted alphabetically, they are ordered by genre ID.

---

<!-- Please follow the template -->

### Prerequisites
*If **all** checks are not passed then the pull request will be closed.*
- [x] I have checked that no other similar pull request already exists.
- [x] My code follows the general code style as the rest of the code.
- [x] I have checked that no sensitive information is exposed.
- [x] Build compiles.
- [x] Build passes test cases.
- [x] I have added/modified documentation (if applicable).
- [x] I have added/modified test cases (if applicable).

**Issue:** *The main issue(s) that this pull request fixes.*
#158, #159, #160

**Workflow Run:** *The link to the MyAnimeList CI workflow run for your branch. Check README for guide on remote tests.*
https://github.com/Katsute/Mal4J/actions/runs/737054101

### Changes Made
*List any changes made and/or other relevant issues.*

- Fixed #158 (incorrect genre IDs)
- Fixed #159 (missing enums)
- Fixed #160 (different IDs for Anime/Manga genres)
