### PR TITLE
Add inverted fields

### DIFF
--- a/src/main/java/com/kttdevelopment/mal4j/AuthResponseHandler.java
+++ b/src/main/java/com/kttdevelopment/mal4j/AuthResponseHandler.java
@@ -27,6 +27,7 @@ package com.kttdevelopment.mal4j;
  * @version 1.1.0
  * @author Ktt Development
  */
+@FunctionalInterface
 public interface AuthResponseHandler {
 
     /**

--- a/src/main/java/com/kttdevelopment/mal4j/Fields.java
+++ b/src/main/java/com/kttdevelopment/mal4j/Fields.java
@@ -22,7 +22,7 @@ package com.kttdevelopment.mal4j;
  * This fields class holds all possible fields for a request. Usable in any methods that ask for fields.
  *
  * @since 1.1.0
- * @version 1.1.0
+ * @version 2.2.0
  * @author Ktt Development
  */
 public abstract class Fields {
@@ -33,6 +33,13 @@ public abstract class Fields {
      * @since 1.1.0
      */
     public static final String[] NO_FIELDS = new String[0];
+
+    /**
+     * Indicates that all fields except the ones supplied should be returned. Add this to the fields parameter.
+     *
+     * @since 2.2.0
+     */
+    public static final String INVERTED = "%INVERTED_MODIFIER%"; // this field should never equal an existing MAL field
 
     // shared
 

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
@@ -123,7 +123,7 @@ public abstract class MyAnimeList {
      * @throws HttpException if request failed
      * @throws UncheckedIOException if client failed to execute request
      * @param id Anime id
-     * @param fields a comma separated string or a string array of the fields that should be returned
+     * @param fields a string array of the fields that should be returned
      * @return Anime
      *
      * @see Anime
@@ -368,7 +368,7 @@ public abstract class MyAnimeList {
      * @throws HttpException if request failed
      * @throws UncheckedIOException if client failed to execute request
      * @param id Manga id
-     * @param fields a comma separated string or a string array of the fields that should be returned
+     * @param fields a string array of the fields that should be returned
      * @return Manga
      *
      * @see Manga
@@ -474,7 +474,7 @@ public abstract class MyAnimeList {
     /**
      * Returns the authenticated user.
      *
-     * @param fields a comma separated string or a string array of the fields that should be returned
+     * @param fields a string array of the fields that should be returned
      * @return user
      * @throws HttpException if request failed
      * @throws UncheckedIOException if client failed to execute request
@@ -505,7 +505,7 @@ public abstract class MyAnimeList {
      * Returns a user given their username.
      *
      * @param username username
-     * @param fields a comma separated string or a string array of the fields that should be returned
+     * @param fields a string array of the fields that should be returned
      * @return user
      * @throws HttpException if request failed
      * @throws UncheckedIOException if client failed to execute request

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -50,7 +50,7 @@ import static com.kttdevelopment.mal4j.MyAnimeListAPIResponseMapping.User.*;
  * @see MyAnimeList
  * @see MyAnimeListService
  * @since 1.0.0
- * @version 2.0.0
+ * @version 2.2.0
  * @author Ktt Development
  */
 final class MyAnimeListImpl extends MyAnimeList{
@@ -94,7 +94,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     )
                 );
@@ -115,7 +115,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
@@ -136,7 +136,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getAnime(
                 auth,
                 id,
-                asFieldList(toCommaSeparatedString(fields), Fields.anime)
+                convertFields(Fields.anime, fields)
             )
         ));
     }
@@ -153,7 +153,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     )
                 );
@@ -174,7 +174,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     ),
                     iterator -> asAnimeRanking(MyAnimeListImpl.this, iterator)
@@ -197,7 +197,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     )
                 );
@@ -220,7 +220,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
@@ -241,7 +241,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     )
                 );
@@ -261,7 +261,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     ),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
@@ -336,7 +336,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     )
                 );
@@ -359,7 +359,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.anime),
+                        convertFields(Fields.anime, fields),
                         nsfw
                     ),
                     iterator -> asAnimeListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
@@ -508,7 +508,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     )
                 );
@@ -529,7 +529,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     ),
                     iterator -> asManga(MyAnimeListImpl.this, iterator.getJsonObject("node"))
@@ -551,7 +551,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getManga(
                 auth,
                 id,
-                asFieldList(toCommaSeparatedString(fields), Fields.manga)
+                convertFields(Fields.manga, fields)
             )
         ));
     }
@@ -568,7 +568,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     )
                 );
@@ -589,7 +589,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     ),
                     iterator -> asMangaRanking(MyAnimeListImpl.this, iterator)
@@ -665,7 +665,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     )
                 );
@@ -688,7 +688,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         limit,
                         offset,
-                        asFieldList(toCommaSeparatedString(fields), Fields.manga),
+                        convertFields(Fields.manga, fields),
                         nsfw
                     ),
                     iterator -> asMangaListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asMangaPreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
@@ -721,7 +721,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getUser(
                 auth,
                 username.equals("@me") ? "@me" : Java9.URLEncoder.encode(username, StandardCharsets.UTF_8),
-                asFieldList(toCommaSeparatedString(fields), Fields.user)
+                convertFields(Fields.user, fields)
             )
         ));
     }
@@ -826,21 +826,6 @@ final class MyAnimeListImpl extends MyAnimeList{
     }
 
     //
-    
-    private static final String inverted = "(?:^%s$|(?<=\\w){%s}|(?:^|,)%s{.*?}|,%s|(?<={)%s,)";
-
-    /**
-     * Handles how fields are finally sent to the server.
-     *
-     * Current behavior sends all if fields are null and none if an empty array is supplied
-     *
-     * @param fields comma separated fields
-     * @param fieldsIfNull fallback fields
-     * @return fields
-     */
-    private static String asFieldList(final String fields, final String fieldsIfNull){
-        return fields == null ? fieldsIfNull : fields;
-    }
 
     private static String toCommaSeparatedString(final List<String> fields){
         return toCommaSeparatedString(fields == null ? null : fields.toArray(new String[0]));
@@ -862,12 +847,33 @@ final class MyAnimeListImpl extends MyAnimeList{
         return null;
     }
 
-    private static String toFields(final String defaultFields, final boolean inverted, final String... fields){
-        if(fields == null)
-            return !inverted ? defaultFields : "";
-        else if(fields.length == 0)
-            return !inverted ? "" : defaultFields;
+    private static final String inverted = "^%s$|^%s(?=,)|(?<=\\w)\\{%s}|(?:^|,)%s\\{.*?}|,%s|(?<=\\{)%s,";
 
+    private static String convertFields(final String defaultFields, final List<String> fields){
+        return convertFields(defaultFields, fields.toArray(new String[0]));
+    }
+
+    /**
+     * Converts field array to comma separated string
+     *
+     * @param defaultFields default fields
+     * @param fields fields
+     * @return comma separated fields
+     */
+    private static String convertFields(final String defaultFields, final String... fields){
+        if(fields == null || fields.length == 0)
+            return defaultFields;
+        else if(fields.length == 1 && fields[0].equals(Fields.INVERTED))
+            return "";
+        
+        boolean inverted = false;
+        for(final String field : fields){
+            if(field.equals(Fields.INVERTED)){
+                inverted = true;
+                break;
+            }
+        }
+        
         if(!inverted){
             final StringBuilder OUT = new StringBuilder();
             for(final String field : fields)
@@ -878,7 +884,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             return str.substring(0, str.length() - 1); // it is asserted that the length is at least 1
         }else{
             String buffer = defaultFields;
-            for(final String field : fields)
+            for(final String field : fields) // remove fields that are specified
                 buffer = buffer.replaceAll(MyAnimeListImpl.inverted.replace("%s", Pattern.quote(field)), "");
             return buffer;
         }

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -861,9 +861,9 @@ final class MyAnimeListImpl extends MyAnimeList{
      * @return comma separated fields
      */
     private static String convertFields(final String defaultFields, final String... fields){
-        if(fields == null || fields.length == 0)
+        if(fields == null || (fields.length == 1 && fields[0].equals(Fields.INVERTED)))
             return defaultFields;
-        else if(fields.length == 1 && fields[0].equals(Fields.INVERTED))
+        else if(fields.length == 0)
             return "";
         
         boolean inverted = false;

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -475,7 +475,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             }
 
             @Override
-            public synchronized final PaginatedIterator<ForumTopic> searchAll(){
+            public final PaginatedIterator<ForumTopic> searchAll(){
                 return new PagedIterator<>(
                     offset,
                     offset -> service.getForumTopics(

--- a/src/main/java/com/kttdevelopment/mal4j/query/FieldQuery.java
+++ b/src/main/java/com/kttdevelopment/mal4j/query/FieldQuery.java
@@ -31,7 +31,7 @@ import java.util.*;
  * @see com.kttdevelopment.mal4j.Fields#anime
  * @see com.kttdevelopment.mal4j.Fields#manga
  * @since 1.0.0
- * @version 1.1.0
+ * @version 2.2.0
  * @author Ktt Development
  */
 @SuppressWarnings({"unchecked", "UnusedReturnValue"})

--- a/src/main/java/com/kttdevelopment/mal4j/query/FieldQuery.java
+++ b/src/main/java/com/kttdevelopment/mal4j/query/FieldQuery.java
@@ -52,6 +52,8 @@ public abstract class FieldQuery<T extends FieldQuery<T,R>,R> extends LimitOffse
      * @see #withFields(String...)
      * @see #withFields(List)
      * @see #withAllFields()
+     * @see #invertFields()
+     * @see #invertFields(boolean)
      * @see #withNoFields()
      * @since 1.0.0
      */
@@ -77,6 +79,8 @@ public abstract class FieldQuery<T extends FieldQuery<T,R>,R> extends LimitOffse
      * @see #withField(String)
      * @see #withFields(List)
      * @see #withAllFields()
+     * @see #invertFields()
+     * @see #invertFields(boolean)
      * @see #withNoFields()
      * @since 1.0.0
      */
@@ -104,6 +108,8 @@ public abstract class FieldQuery<T extends FieldQuery<T,R>,R> extends LimitOffse
      * @see #withField(String)
      * @see #withFields(String...)
      * @see #withAllFields()
+     * @see #invertFields()
+     * @see #invertFields(boolean)
      * @see #withNoFields()
      * @since 1.0.0
      */
@@ -129,11 +135,55 @@ public abstract class FieldQuery<T extends FieldQuery<T,R>,R> extends LimitOffse
      * @see #withField(String)
      * @see #withFields(String...)
      * @see #withFields(List)
+     * @see #invertFields()
+     * @see #invertFields(boolean)
      * @see #withNoFields()
      * @since 1.0.0
      */
     public final T withAllFields(){
         this.fields = null;
+        return (T) this;
+    }
+
+    /**
+     * Makes the query return all except the fields provided.
+     *
+     * @return query
+     *
+     * @see #withField(String)
+     * @see #withFields(String...)
+     * @see #withFields(List)
+     * @see #withAllFields()
+     * @see #invertFields(boolean)
+     * @see #withNoFields()
+     * @since 2.2.0
+     */
+    public final T invertFields(){
+        return withField(Fields.INVERTED);
+    }
+
+    /**
+     * Makes the query return all except the fields provided.
+     *
+     * @param inverted whether the fields should be inverted or not
+     * @return query
+     *
+     * @see #withField(String)
+     * @see #withFields(String...)
+     * @see #withFields(List)
+     * @see #withAllFields()
+     * @see #invertFields()
+     * @see #withNoFields()
+     * @since 2.2.0
+     */
+    public final T invertFields(final boolean inverted){
+        if(inverted)
+            return withField(Fields.INVERTED);
+        else if(fields != null){
+            fields.remove(Fields.INVERTED);
+            if(fields.isEmpty())
+                fields = null;
+        }
         return (T) this;
     }
 
@@ -147,6 +197,8 @@ public abstract class FieldQuery<T extends FieldQuery<T,R>,R> extends LimitOffse
      * @see #withFields(String...)
      * @see #withFields(List)
      * @see #withAllFields()
+     * @see #invertFields()
+     * @see #invertFields(boolean)
      * @since 1.0.0
      */
     public final T withNoFields(){

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.mal4j.AnimeTests;
 
 import com.kttdevelopment.mal4j.*;
 import com.kttdevelopment.mal4j.anime.*;
+import com.kttdevelopment.mal4j.manga.Manga;
 import com.kttdevelopment.mal4j.manga.RelatedManga;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -119,6 +120,26 @@ public class TestAnime {
     @Test
     public void testJapaneseEncoding(){
         Assertions.assertFalse(anime.getAlternativeTitles().getJapanese().startsWith("\\u"), "Japanese characters should not be returned as a literal \\u unicode string");
+    }
+
+    @Test
+    public void testFields(){
+        final Anime anime = mal.getAnime(TestProvider.AnimeID, Fields.Anime.episodes);
+        Assertions.assertNotNull(anime.getEpisodes());
+        Assertions.assertNull(anime.getRating());
+    }
+
+    @Test
+    public void testInvertedFields(){
+        final Anime anime = mal.getAnime(TestProvider.AnimeID, Fields.Anime.episodes, Fields.INVERTED);
+        Assertions.assertNull(anime.getEpisodes());
+        Assertions.assertNotNull(anime.getRating());
+    }
+
+    @Test
+    public void testInvertedFieldsOnly(){
+        final Anime manga = mal.getAnime(TestProvider.AnimeID, Fields.INVERTED);
+        Assertions.assertNull(manga.getEpisodes());
     }
 
     @Test @DisplayName("Anime may not have related Manga") @Disabled

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -137,7 +137,7 @@ public class TestAnime {
     @Test
     public void testInvertedFieldsOnly(){
         final Anime manga = mal.getAnime(TestProvider.AnimeID, Fields.INVERTED);
-        Assertions.assertNull(manga.getEpisodes());
+        Assertions.assertNotNull(manga.getEpisodes());
     }
 
     @Test @DisplayName("Anime may not have related Manga") @Disabled

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -2,7 +2,6 @@ package com.kttdevelopment.mal4j.AnimeTests;
 
 import com.kttdevelopment.mal4j.*;
 import com.kttdevelopment.mal4j.anime.*;
-import com.kttdevelopment.mal4j.manga.Manga;
 import com.kttdevelopment.mal4j.manga.RelatedManga;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,7 +13,6 @@ import java.util.stream.Stream;
 
 public class TestAnime {
 
-    @SuppressWarnings("FieldCanBeLocal")
     private static MyAnimeList mal;
     private static Anime anime;
 

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -115,7 +115,7 @@ public class TestManga {
     @Test
     public void testInvertedFieldsOnly(){
         final Manga manga = mal.getManga(TestProvider.MangaID, Fields.INVERTED);
-        Assertions.assertNull(manga.getVolumes());
+        Assertions.assertNotNull(manga.getVolumes());
     }
 
     @Test @DisplayName("Manga may not have related Anime") @Disabled

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -1,7 +1,6 @@
 package com.kttdevelopment.mal4j.MangaTests;
 
 import com.kttdevelopment.mal4j.*;
-import com.kttdevelopment.mal4j.anime.Anime;
 import com.kttdevelopment.mal4j.anime.RelatedAnime;
 import com.kttdevelopment.mal4j.manga.Manga;
 import org.junit.jupiter.api.*;
@@ -14,7 +13,6 @@ import java.util.stream.Stream;
 
 public class TestManga {
 
-    @SuppressWarnings("FieldCanBeLocal")
     private static MyAnimeList mal;
     private static Manga manga;
 

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestManga.java
@@ -1,6 +1,7 @@
 package com.kttdevelopment.mal4j.MangaTests;
 
 import com.kttdevelopment.mal4j.*;
+import com.kttdevelopment.mal4j.anime.Anime;
 import com.kttdevelopment.mal4j.anime.RelatedAnime;
 import com.kttdevelopment.mal4j.manga.Manga;
 import org.junit.jupiter.api.*;
@@ -97,6 +98,26 @@ public class TestManga {
     @Test
     public void testJapaneseEncoding(){
         Assertions.assertFalse(manga.getAlternativeTitles().getJapanese().startsWith("\\u"), "Japanese characters should not be returned as a literal \\u unicode string");
+    }
+
+    @Test
+    public void testFields(){
+        final Manga manga = mal.getManga(TestProvider.MangaID, Fields.Manga.volumes);
+        Assertions.assertNotNull(manga.getVolumes());
+        Assertions.assertNull(manga.getChapters());
+    }
+
+    @Test
+    public void testInvertedFields(){
+        final Manga manga = mal.getManga(TestProvider.MangaID, Fields.Manga.volumes, Fields.INVERTED);
+        Assertions.assertNull(manga.getVolumes());
+        Assertions.assertNotNull(manga.getChapters());
+    }
+
+    @Test
+    public void testInvertedFieldsOnly(){
+        final Manga manga = mal.getManga(TestProvider.MangaID, Fields.INVERTED);
+        Assertions.assertNull(manga.getVolumes());
     }
 
     @Test @DisplayName("Manga may not have related Anime") @Disabled

--- a/src/test/java/com/kttdevelopment/mal4j/TestJava9.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestJava9.java
@@ -45,6 +45,7 @@ public class TestJava9 {
         return sb.toString();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testNullEncoder(){
         Assertions.assertThrows(NullPointerException.class, () -> Java9.URLEncoder.encode("Hello World", null));

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -1,6 +1,10 @@
 package com.kttdevelopment.mal4j;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.regex.Pattern;
 
 public class TestMyAnimeList {
 
@@ -54,6 +58,20 @@ public class TestMyAnimeList {
     @Test
     public void testNullUser(){
         Assertions.assertThrows(NullPointerException.class, () -> mal.getUser(null));
+    }
+
+    private static final String inverted = "^%s$|^%s(?=,)|(?<=\\w)\\{%s}|(?:^|,)%s\\{.*?}|,%s|(?<=\\{)%s,";
+
+    @ParameterizedTest
+    @ValueSource(strings={"%s", "%s,%s", "a,%s", "a{%s}", "%s{a}", "a{%s}", "a{a,%s}", "a{%s,a}"})
+    public void testInvertedRegex(final String raw){
+        final String inv = raw.replaceAll(inverted, "");
+        Assertions.assertFalse(inv.contains("%s"));
+        Assertions.assertFalse(inv.contains("{}"));
+        Assertions.assertFalse(inv.contains("{,"));
+        Assertions.assertFalse(inv.contains(",}"));
+        Assertions.assertFalse(inv.startsWith(","));
+        Assertions.assertFalse(inv.endsWith(","));
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -65,13 +65,14 @@ public class TestMyAnimeList {
     @ParameterizedTest
     @ValueSource(strings={"%s", "%s,%s", "a,%s", "a{%s}", "%s{a}", "a{%s}", "a{a,%s}", "a{%s,a}"})
     public void testInvertedRegex(final String raw){
+        final String sf = "[%s]: '%s' should not have contained '%s'";
         final String inv = raw.replaceAll(inverted, "");
-        Assertions.assertFalse(inv.contains("%s"));
-        Assertions.assertFalse(inv.contains("{}"));
-        Assertions.assertFalse(inv.contains("{,"));
-        Assertions.assertFalse(inv.contains(",}"));
-        Assertions.assertFalse(inv.startsWith(","));
-        Assertions.assertFalse(inv.endsWith(","));
+        Assertions.assertFalse(inv.contains("%s"), String.format(sf, raw, inv, "%s"));
+        Assertions.assertFalse(inv.contains("{}"), String.format(sf, raw, inv, "{}"));
+        Assertions.assertFalse(inv.contains("{,"), String.format(sf, raw, inv, "{,"));
+        Assertions.assertFalse(inv.contains(",}"), String.format(sf, raw, inv, ",}"));
+        Assertions.assertFalse(inv.startsWith(","), String.format(sf, raw, inv, ",$"));
+        Assertions.assertFalse(inv.endsWith(","), String.format(sf, raw, inv, "^,"));
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.regex.Pattern;
-
 public class TestMyAnimeList {
 
     private static MyAnimeList mal;


### PR DESCRIPTION
### Prerequisites
*If **all** checks are not passed then the pull request will be closed.*
- [x] I have checked that no other similar pull request already exists.
- [x] My code follows the general code style as the rest of the code.
- [x] I have checked that no sensitive information is exposed.
- [x] Build compiles.
- [x] Build passes test cases.
- [x] I have added/modified documentation (check if not applicable).
- [x] I have added/modified test cases (check if not applicable).

**Issue:** *The main issue(s) that this pull request fixes.*
#170 

**Workflow Run:** *The link to the MyAnimeList CI workflow run for your branch. Check README for guide on remote tests.*
https://github.com/Katsute/Mal4J/runs/2569301593

### Changes Made
*List any changes made and/or other relevant issues.*

- Adds inverted fields (ability to return all except select fields)
- Adds inverted fields to query object

**Example usage:**
```java
MyAnimeList mal;
Anime anime = mal.get(13759, Fields.Anime.episodes, Fields.INVERTED);

anime.getEpisodes(); // would be null because fields are inverted
anime.getRating(); // would not be null because ratings field was not part of supplied parameter
```
