### PR TITLE
Bump crazy-max/ghaction-import-gpg from 3 to 3.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: 🔐 Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v3.1.0
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
Manually created because dependabot fails to notice that a new version is available.

Replaces #176 