### PR TITLE
Bump org.junit.jupiter from 5.7.1 to 5.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,13 +245,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.1</version>
+            <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.7.1</version>
+            <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bumps JUnit from 5.7.1 to 5.7.2

- Mainly bugfixes

[Full changelog](https://junit.org/junit5/docs/5.7.2/release-notes/)