### PR TITLE
Ability to authenticate using client ID

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,7 +20,7 @@ body:
           required: true
         - label: I have checked the [known issues](https://github.com/Katsute/Mal4J/projects/10) for this library.
           required: true
-        - label: I have checked the [FAQ](https://github.com/Katsute/Mal4J/blob/main/faq.md).
+        - label: I have checked the [FAQ](https://github.com/Katsute/Mal4J/blob/main/faq.md#readme).
           required: true
 
   - type: input

--- a/.github/workflows/mal_ci.yml
+++ b/.github/workflows/mal_ci.yml
@@ -7,11 +7,12 @@ concurrency: mal-test
 
 jobs:
   mal_ci:
-    name: MyAnimeList CI (Java ${{ matrix.java }})
+    name: MyAnimeList CI [${{ matrix.auth }}] (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
+        auth: ["Client", "Token"]
         java: [8, 11, 17]
       fail-fast: false
       max-parallel: 1
@@ -26,9 +27,15 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
 
-      - name: 🔐 Load OAuth Token
+      - name: 🔐 Load Client ID
+        if: matrix.auth == 'Client'
         run: |
-          echo ${{ secrets.MAL_OAUTH }} > src/test/java/resources/oauth.txt
+          echo ${{ secrets.MAL_CLIENT }} > src/test/java/resources/client.txt
+
+      - name: 🔐 Load OAuth Token
+        if: matrix.auth == 'Token'
+        run: |
+          echo ${{ secrets.MAL_TOKEN }} > src/test/java/resources/token.txt
 
       - name: ✔ Test with Maven
         run: mvn test -fae --no-transfer-progress

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
         •
         <a href="https://myanimelist.net/apiconfig/references/api/v2">API Docs</a>
         •
-        <a href="https://github.com/Katsute/Mal4J/blob/main/setup.md">Setup</a>
+        <a href="https://github.com/Katsute/Mal4J/blob/main/setup.md#readme">Setup</a>
         •
-        <a href="https://github.com/Katsute/Mal4J/blob/main/faq.md">FAQ</a>
+        <a href="https://github.com/Katsute/Mal4J/blob/main/faq.md#readme">FAQ</a>
         •
         <a href="https://github.com/Katsute/Mal4J/issues">Issues</a>
         •
@@ -63,7 +63,7 @@ Compiled jars can be found on [Maven Central](https://mvnrepository.com/artifact
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.kttdevelopment/mal4j)](https://mvnrepository.com/artifact/com.kttdevelopment/mal4j) [![Releases](https://img.shields.io/github/v/release/Katsute/Mal4J)](https://github.com/Katsute/Mal4J/releases)
 
-See [setup](https://github.com/Katsute/Mal4J/blob/main/setup.md) for steps to authenticate and actually use this library.
+See [setup](https://github.com/Katsute/Mal4J/blob/main/setup.md#readme) for steps to authenticate and actually use this library.
 
 <p align="right">(<a href="#readme">back to top</a>)</p>
 
@@ -74,7 +74,7 @@ See [setup](https://github.com/Katsute/Mal4J/blob/main/setup.md) for steps to au
 Easily search through MyAnimeList with search, ranking, seasonal, and suggestion queries; returning only selected or all fields.
 
 ```java
-MyAnimeList mal = MyAnimeList.withToken("");
+MyAnimeList mal = MyAnimeList.withClientID("");
 List<AnimePreview> search =
     mal.getAnime()
         .withQuery("さくら荘のペットな彼女")
@@ -109,7 +109,7 @@ MangaListStatus status =
 **All** information provided in the [MyAnimeList API](https://myanimelist.net/apiconfig/references/api/v2) including Anime, Manga, forums, genres, pictures, statistics, and even some *undocumented* fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 ```java
-MyAnimeList mal = MyAnimeList.withToken("");
+MyAnimeList mal = MyAnimeList.withClientID("");
 Anime anime = mal.getAnime(13759);
 
 String ja = anime.getAlternativeTitles().getJapanese();

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [setup](https://github.com/Katsute/Mal4J/blob/main/setup.md) for steps to au
 Easily search through MyAnimeList with search, ranking, seasonal, and suggestion queries; returning only selected or all fields.
 
 ```java
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 List<AnimePreview> search =
     mal.getAnime()
         .withQuery("さくら荘のペットな彼女")
@@ -89,7 +89,7 @@ List<AnimePreview> search =
 Easily update your Anime and Manga listings through update methods.
 
 ```java
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 MangaListStatus status =
     mal.updateMangaListing(28107)
         .status(MangaStatus.Reading)
@@ -109,7 +109,7 @@ MangaListStatus status =
 **All** information provided in the [MyAnimeList API](https://myanimelist.net/apiconfig/references/api/v2) including Anime, Manga, forums, genres, pictures, statistics, and even some *undocumented* fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 ```java
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 Anime anime = mal.getAnime(13759);
 
 String ja = anime.getAlternativeTitles().getJapanese();

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Please note that the client ID being used for tests must not have a client secre
 
 ### Running Tests Remotely
 
-Devs running remote tests may do so by running the `MyAnimeList CI` workflow manually in the actions tab of your fork. Note that this requires a secret `MAL_OAUTH` which contains the OAuth token (ex: `Bearer <oauth token>`).
+Devs running remote tests may do so by running the `MyAnimeList CI` workflow manually in the actions tab of your fork. Note that this requires two secrets, a `MAL_CLIENT` which contains the client ID, and a `MAL_TOKEN` which contains the OAuth token (ex: `Bearer <oauth token>`).
 
 <p align="right">(<a href="#readme">back to top</a>)</p>
 

--- a/faq.md
+++ b/faq.md
@@ -41,9 +41,11 @@ The MyAnimeList API currently has no rate limit in place so requests must be sen
 
 This library offers ***ALL*** the features provided by the API and even some *undocumented* fields.
 
-### My auth token doesn't work.
+### My client id / auth token doesn't work.
 
-- Make sure that you are providing an auth token and not the client id.
+- Make sure you are using the correct authentication method
+    - For client id use: [`#withClientID`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withClientID(java.lang.String)
+    - For token use: [`#withToken`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withToken(java.lang.String)
 - Your token may be expired.
 - Your token is missing '`Bearer `'.
 - Your token may contain dangling whitespace.

--- a/faq.md
+++ b/faq.md
@@ -2,7 +2,7 @@
 
 ### Does this library support Java # ?
 
-This project supports Java 8+ and Java 9 modules.
+This project supports Java 8+ and Java 9+ modules.
 
 ### WARNING: An illegal reflective access operation has occurred
 
@@ -44,8 +44,8 @@ This library offers ***ALL*** the features provided by the API and even some *un
 ### My client id / auth token doesn't work.
 
 - Make sure you are using the correct authentication method
-    - For client id use: [`#withClientID`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withClientID(java.lang.String)
-    - For token use: [`#withToken`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withToken(java.lang.String)
+    - For client id use: [`#withClientID`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withClientID(java.lang.String))
+    - For token use: [`#withToken`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withToken(java.lang.String))
 - Your token may be expired.
 - Your token is missing '`Bearer `'.
 - Your token may contain dangling whitespace.
@@ -65,6 +65,10 @@ For search queries make sure you also run [`#includeNSFW()`](https://docs.katsut
 ### I can't get other users.
 
 Currently the MyAnimeList API does not allow you to check users other than yourself.
+
+### I can't get or modify my Anime/Manga lists.
+
+In order to write or read private data you must authenticate using a [token](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withToken(java.lang.String)) or with an [authenticator](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeList.html#withAuthorization(com.kttdevelopment.mal4j.MyAnimeListAuthenticator)).
 
 ### `list_status` / `my_list_status` field isn't working.
 

--- a/readme.bbcode
+++ b/readme.bbcode
@@ -11,7 +11,7 @@ Mal4J is a wrapper for the MyAnimeList API written for Java 8 and simplifies man
 Easily search through MyAnimeList with search, ranking, seasonal, and suggestion queries; returning only selected or all fields.
 
 [code]
-MyAnimeList mal = MyAnimeList.withToken("");
+MyAnimeList mal = MyAnimeList.withClientID("");
 List<AnimePreview> search =
     mal.getAnime()
         .withQuery("さくら荘のペットな彼女")
@@ -44,7 +44,7 @@ MangaListStatus status =
 [b]All[/b] information provided in the [url=https://myanimelist.net/apiconfig/references/api/v2]MyAnimeList API[/url] including Anime, Manga, forums, genres, pictures, statistics, and even some [i]undocumented[/i] fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 [code]
-MyAnimeList mal = MyAnimeList.withToken("");
+MyAnimeList mal = MyAnimeList.withClientID("");
 Anime anime = mal.getAnime(13759);
 
 String ja = anime.getAlternativeTitles().getJapanese();

--- a/readme.bbcode
+++ b/readme.bbcode
@@ -11,7 +11,7 @@ Mal4J is a wrapper for the MyAnimeList API written for Java 8 and simplifies man
 Easily search through MyAnimeList with search, ranking, seasonal, and suggestion queries; returning only selected or all fields.
 
 [code]
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 List<AnimePreview> search =
     mal.getAnime()
         .withQuery("さくら荘のペットな彼女")
@@ -25,7 +25,7 @@ List<AnimePreview> search =
 Easily update your Anime and Manga listings through update methods.
 
 [code]
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 MangaListStatus status =
     mal.updateMangaListing(28107)
         .status(MangaStatus.Reading)
@@ -44,7 +44,7 @@ MangaListStatus status =
 [b]All[/b] information provided in the [url=https://myanimelist.net/apiconfig/references/api/v2]MyAnimeList API[/url] including Anime, Manga, forums, genres, pictures, statistics, and even some [i]undocumented[/i] fields are accessible in this library. Effortlessly retrieve any and all information you need.
 
 [code]
-MyAnimeList mal = MyAnimeList.withOAuthToken("");
+MyAnimeList mal = MyAnimeList.withToken("");
 Anime anime = mal.getAnime(13759);
 
 String ja = anime.getAlternativeTitles().getJapanese();

--- a/setup.md
+++ b/setup.md
@@ -8,10 +8,6 @@ Compiled jars can be found on [Maven Central](https://mvnrepository.com/artifact
 
 # API setup
 
-The below method is massively simplified, for a more detailed explanation on OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
-
-If you want to quickly generate a token you can use this [python script](https://gitlab.com/-/snippets/2039434).
-
 ## 1. Create new Client ID
 
   - In order to use the MyAnimeList API you must retrieve your own client ID.
@@ -42,15 +38,31 @@ This library also supports OAuth token refresh.
 
 It is suggested that you save the OAuth token that is generated so you don't have to authenticate with MyAnimeList each time.
 
+### Authenticate using client
+
+ - Simply use the client ID for your application. Client secret is not required, even if your application has one.
+
+   ```java
+   MyAnimeList mal = MyAnimeList.withClientID("client_id");
+   ```
+
+   This authentication method only grants access to public data and READ operations.
+
+   If you want to view users, or view or change anime/manga lists you must authenticate with a [token](#authenticate-using-token) or with [oauth 2.0](#authenticate-with-client-id-using-oauth-20)
+
 ### Authenticate using token
 
   - For developers using their own [authorization](https://myanimelist.net/apiconfig/references/authorization#client-registration) you can simply use the OAuth token that you generate.
 
     ```java
-    MyAnimeList mal = MyAnimeList.withOAuthToken("oauth_token");
+    MyAnimeList mal = MyAnimeList.withToken("Bearer oauth_token");
     ```
 
 ### Authenticate with client id using OAuth 2.0
+
+The below method is massively simplified, for a more detailed explanation on OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
+
+If you want to quickly generate a token you can use this [python script](https://gitlab.com/-/snippets/2039434).
 
 For developers using their own [authorization](https://myanimelist.net/apiconfig/references/authorization#step-1-generate-a-code-verifier-and-challenge) methods you can use the [`MyAnimeListAuthenticator`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.html) to generate an OAuth token from a client id and PKCE code challenge.
 
@@ -72,6 +84,8 @@ For developers using their own [authorization](https://myanimelist.net/apiconfig
     MyAnimeList mal = MyAnimeList.withAuthorization(new MyAnimeListAuthenticator("client_id", "client_secret", "authorization_code", "PKCE_code_challenge"));
     ```
 
+The above methods is massively simplified, for a more detailed guide on how OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
+
 ### Authenticate with client id using a local server
 
   - For developers without domain for the app redirect url (using *localhost*), authorization can be completed using the [`MyAnimeListAuthenticator`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.html).
@@ -87,7 +101,3 @@ For developers using their own [authorization](https://myanimelist.net/apiconfig
     ```java
     MyAnimeList mal = MyAnimeList.withAuthorization(new MyAnimeListAuthenticator.LocalServerBuilder("client_id", "client_secret", 5050).openBrowser().build());
     ```
-
-<hr>
-
-The above methods are massively simplified, for a more detailed guide on how OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).

--- a/setup.md
+++ b/setup.md
@@ -38,7 +38,14 @@ This library also supports OAuth token refresh.
 
 It is suggested that you save the OAuth token that is generated so you don't have to authenticate with MyAnimeList each time.
 
-### Authenticate using client
+Four different ways to authenticate with MyAnimeList:
+
+ - [Authenticate using client](#authenticate-using-client-id)
+ - [Authenticate using token](#authenticate-using-token)
+ - [Authenticate using OAuth 2.0](#authenticate-using-oauth-20)
+ - [Authenticate with using a local server](#authenticate-using-a-local-server)
+
+### Authenticate using client ID
 
  - Simply use the client ID for your application. Client secret is not required, even if your application has one.
 
@@ -48,7 +55,7 @@ It is suggested that you save the OAuth token that is generated so you don't hav
 
    This authentication method only grants access to public data and READ operations.
 
-   If you want to view users, or view or change anime/manga lists you must authenticate with a [token](#authenticate-using-token) or with [oauth 2.0](#authenticate-with-client-id-using-oauth-20)
+   If you want to view users, or view or change anime/manga lists you must authenticate with a [token](#authenticate-using-token) or with [oauth 2.0](#authenticate-using-oauth-20)
 
 ### Authenticate using token
 
@@ -58,7 +65,7 @@ It is suggested that you save the OAuth token that is generated so you don't hav
     MyAnimeList mal = MyAnimeList.withToken("Bearer oauth_token");
     ```
 
-### Authenticate with client id using OAuth 2.0
+### Authenticate using OAuth 2.0
 
 The below method is massively simplified, for a more detailed explanation on OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
 
@@ -86,7 +93,7 @@ For developers using their own [authorization](https://myanimelist.net/apiconfig
 
 The above methods is massively simplified, for a more detailed guide on how OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
 
-### Authenticate with client id using a local server
+### Authenticate with using a local server
 
   - For developers without domain for the app redirect url (using *localhost*), authorization can be completed using the [`MyAnimeListAuthenticator`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.html).
 

--- a/setup.md
+++ b/setup.md
@@ -34,13 +34,9 @@ Compiled jars can be found on [Maven Central](https://mvnrepository.com/artifact
 
 This library has a simplified authentication method based of the MyAnimeList [authorization documentation](https://myanimelist.net/apiconfig/references/authorization#client-registration). You can implement your own authentication methods or use the ones provided here.
 
-This library also supports OAuth token refresh.
-
-It is suggested that you save the OAuth token that is generated so you don't have to authenticate with MyAnimeList each time.
-
 Four different ways to authenticate with MyAnimeList:
 
- - [Authenticate using client](#authenticate-using-client-id)
+ - [Authenticate using client ID](#authenticate-using-client-id)
  - [Authenticate using token](#authenticate-using-token)
  - [Authenticate using OAuth 2.0](#authenticate-using-oauth-20)
  - [Authenticate with using a local server](#authenticate-using-a-local-server)
@@ -91,9 +87,11 @@ For developers using their own [authorization](https://myanimelist.net/apiconfig
     MyAnimeList mal = MyAnimeList.withAuthorization(new MyAnimeListAuthenticator("client_id", "client_secret", "authorization_code", "PKCE_code_challenge"));
     ```
 
+    It is suggested that you save the OAuth token that is generated so you don't have to authenticate with MyAnimeList each time.
+
 The above methods is massively simplified, for a more detailed guide on how OAuth2.0 works check this blog post: [OAuth2.0 authorization for MAL](https://myanimelist.net/blog.php?eid=835707).
 
-### Authenticate with using a local server
+### Authenticate using a local server
 
   - For developers without domain for the app redirect url (using *localhost*), authorization can be completed using the [`MyAnimeListAuthenticator`](https://docs.katsute.dev/mal4j/javadoc/Mal4J/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.html).
 

--- a/setup.md
+++ b/setup.md
@@ -39,7 +39,7 @@ Four different ways to authenticate with MyAnimeList:
  - [Authenticate using client ID](#authenticate-using-client-id)
  - [Authenticate using token](#authenticate-using-token)
  - [Authenticate using OAuth 2.0](#authenticate-using-oauth-20)
- - [Authenticate with using a local server](#authenticate-using-a-local-server)
+ - [Authenticate using a local server](#authenticate-using-a-local-server)
 
 ### Authenticate using client ID
 

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
@@ -39,12 +39,13 @@ import java.util.List;
  * <br><br>
  * The {@link MyAnimeList} class can be created by authenticating with either:
  * <ul>
- *     <li>An oauth token using {@link #withOAuthToken(String)}</li>
+ *     <li>A client ID using {@link #withClientID(String)}</li>
+ *     <li>An OAuth token using {@link #withOAuthToken(String)}</li>
  *     <li>An authorization code and client id using {@link #withAuthorization(MyAnimeListAuthenticator)}.</li>
  * </ul>
  *
  * @since 1.0.0
- * @version 2.4.0
+ * @version 2.6.0
  * @author Katsute
  */
 public abstract class MyAnimeList {
@@ -52,19 +53,35 @@ public abstract class MyAnimeList {
     MyAnimeList(){ }
 
     /**
+     * Creates an interface with a client ID. Only public read operations are allowed, for write and user operations use {@link #withOAuthToken(String)} or {@link #withAuthorization(MyAnimeListAuthenticator)}. Client secret is not required if your application has one.
+     *
+     * @param client_id client id
+     * @return MyAnimeList
+     * @throws NullPointerException if client ID is null
+     *
+     * @see #withOAuthToken(String)
+     * @see #withAuthorization(MyAnimeListAuthenticator)
+     */
+    @SuppressWarnings("GrazieInspection")
+    public static MyAnimeList withClientID(final String client_id){
+        return new MyAnimeListImpl(client_id, false);
+    }
+
+    /**
      * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshOAuthToken()}.
      *
      * @param token OAuth token, Ex: 'Bearer oauth2token'
+     * @return MyAnimeList
      * @throws NullPointerException if token is null
      * @throws InvalidTokenException if token doesn't start with 'Bearer'
      *
-     * @return MyAnimeList
      *
+     * @see #withClientID(String)
      * @see #withAuthorization(MyAnimeListAuthenticator)
      * @since 1.0.0
      */
     public static MyAnimeList withOAuthToken(final String token){
-        return new MyAnimeListImpl(token);
+        return new MyAnimeListImpl(token, true);
     }
 
     /**
@@ -74,6 +91,7 @@ public abstract class MyAnimeList {
      * @return MyAnimeList
      * @throws NullPointerException if authenticator is null
      *
+     * @see #withClientID(String)
      * @see #withOAuthToken(String)
      * @see #refreshOAuthToken()
      * @see MyAnimeListAuthenticator
@@ -121,11 +139,11 @@ public abstract class MyAnimeList {
     /**
      * Returns the full Anime details given an ID.
      *
+     * @param id Anime id
+     * @return Anime
      * @throws HttpException if request failed
      * @throws InvalidTokenException if token is invalid or expired
      * @throws UncheckedIOException if client failed to execute request
-     * @param id Anime id
-     * @return Anime
      *
      * @see Anime
      * @see #getAnime(long)
@@ -136,12 +154,12 @@ public abstract class MyAnimeList {
     /**
      * Returns Anime details requested in the fields given an ID.
      *
-     * @throws HttpException if request failed
-     * @throws InvalidTokenException if token is invalid or expired
-     * @throws UncheckedIOException if client failed to execute request
      * @param id Anime id
      * @param fields a string array of the fields that should be returned
      * @return Anime
+     * @throws HttpException if request failed
+     * @throws InvalidTokenException if token is invalid or expired
+     * @throws UncheckedIOException if client failed to execute request
      *
      * @see Anime
      * @see #getAnime()
@@ -219,10 +237,10 @@ public abstract class MyAnimeList {
     /**
      * Removes an Anime listing.
      *
+     * @param id Anime id
      * @throws HttpException if request failed
      * @throws InvalidTokenException if token is invalid or expired
      * @throws UncheckedIOException if client failed to execute request
-     * @param id Anime id
      *
      * @see #updateAnimeListing(long)
      * @see #getUserAnimeListing()
@@ -373,11 +391,11 @@ public abstract class MyAnimeList {
     /**
      * Returns the full Manga details given an ID.
      *
+     * @param id Manga id
+     * @return Manga
      * @throws HttpException if request failed
      * @throws InvalidTokenException if token is invalid or expired
      * @throws UncheckedIOException if client failed to execute request
-     * @param id Manga id
-     * @return Manga
      *
      * @see Manga
      * @see #getManga(long)
@@ -388,12 +406,12 @@ public abstract class MyAnimeList {
     /**
      * Returns Manga details requested in the fields given an ID.
      *
-     * @throws HttpException if request failed
-     * @throws InvalidTokenException if token is invalid or expired
-     * @throws UncheckedIOException if client failed to execute request
      * @param id Manga id
      * @param fields a string array of the fields that should be returned
      * @return Manga
+     * @throws HttpException if request failed
+     * @throws InvalidTokenException if token is invalid or expired
+     * @throws UncheckedIOException if client failed to execute request
      *
      * @see Manga
      * @see #getManga()
@@ -439,10 +457,10 @@ public abstract class MyAnimeList {
     /**
      * Removes a Manga listing.
      *
+     * @param id Manga id
      * @throws HttpException if request failed
      * @throws InvalidTokenException if token is invalid or expired
      * @throws UncheckedIOException if client failed to execute request
-     * @param id Manga id
      *
      * @see #updateMangaListing(long)
      * @see #getUserMangaListing()

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
@@ -40,7 +40,7 @@ import java.util.List;
  * The {@link MyAnimeList} class can be created by authenticating with either:
  * <ul>
  *     <li>A client ID using {@link #withClientID(String)}</li>
- *     <li>An OAuth token using {@link #withOAuthToken(String)}</li>
+ *     <li>An OAuth token using {@link #withToken(String)}</li>
  *     <li>An authorization code and client id using {@link #withAuthorization(MyAnimeListAuthenticator)}.</li>
  * </ul>
  *
@@ -53,13 +53,13 @@ public abstract class MyAnimeList {
     MyAnimeList(){ }
 
     /**
-     * Creates an interface with a client ID. Only public read operations are allowed, for write and user operations use {@link #withOAuthToken(String)} or {@link #withAuthorization(MyAnimeListAuthenticator)}. Client secret is not required if your application has one.
+     * Creates an interface with a client ID. Only public read operations are allowed, for write and user operations use {@link #withToken(String)} or {@link #withAuthorization(MyAnimeListAuthenticator)}. Client secret is not required if your application has one.
      *
      * @param client_id client id
      * @return MyAnimeList
      * @throws NullPointerException if client ID is null
      *
-     * @see #withOAuthToken(String)
+     * @see #withToken(String)
      * @see #withAuthorization(MyAnimeListAuthenticator)
      */
     @SuppressWarnings("GrazieInspection")
@@ -68,7 +68,7 @@ public abstract class MyAnimeList {
     }
 
     /**
-     * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshOAuthToken()}.
+     * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshToken()}.
      *
      * @param token OAuth token, Ex: 'Bearer oauth2token'
      * @return MyAnimeList
@@ -78,10 +78,30 @@ public abstract class MyAnimeList {
      *
      * @see #withClientID(String)
      * @see #withAuthorization(MyAnimeListAuthenticator)
-     * @since 1.0.0
+     * @since 2.6.0
      */
-    public static MyAnimeList withOAuthToken(final String token){
+    public static MyAnimeList withToken(final String token){
         return new MyAnimeListImpl(token, true);
+    }
+
+    /**
+     * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshToken()}.
+     *
+     * @deprecated this method has been renamed to {@link #withToken(String)} for simplicity
+     * @param token OAuth token, Ex: 'Bearer oauth2token'
+     * @return MyAnimeList
+     * @throws NullPointerException if token is null
+     * @throws InvalidTokenException if token doesn't start with 'Bearer'
+     *
+     *
+     * @see #withClientID(String)
+     * @see #withAuthorization(MyAnimeListAuthenticator)
+     * @since 1.0.0
+     * @see #withToken(String)
+     */
+    @Deprecated
+    public static MyAnimeList withOAuthToken(final String token){
+        return withToken(token);
     }
 
     /**
@@ -92,8 +112,8 @@ public abstract class MyAnimeList {
      * @throws NullPointerException if authenticator is null
      *
      * @see #withClientID(String)
-     * @see #withOAuthToken(String)
-     * @see #refreshOAuthToken()
+     * @see #withToken(String)
+     * @see #refreshToken()
      * @see MyAnimeListAuthenticator
      * @since 1.0.0
      */
@@ -104,10 +124,22 @@ public abstract class MyAnimeList {
     /**
      * Refreshes the OAuth token. Only works with {@link #withAuthorization(MyAnimeListAuthenticator)}.
      *
-     * @throws UnsupportedOperationException if this wasn't created with an authenticator.
+     * @throws UnsupportedOperationException if this wasn't created with an authenticator
+     *
+     * @since 2.6.0
+     */
+    public abstract void refreshToken();
+
+    /**
+     * Refreshes the OAuth token. Only works with {@link #withAuthorization(MyAnimeListAuthenticator)}.
+     *
+     * @deprecated this method has been renamed to {@link #refreshToken()} for simplicity
+     * @throws UnsupportedOperationException if this wasn't created with an authenticator
      *
      * @since 1.0.0
+     * @see #refreshToken()
      */
+    @Deprecated
     public abstract void refreshOAuthToken();
 
     // experimental

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -83,10 +83,15 @@ final class MyAnimeListImpl extends MyAnimeList {
     }
 
     @Override
-    public synchronized final void refreshOAuthToken(){
+    public synchronized final void refreshToken(){
         if(authenticator == null)
             throw new UnsupportedOperationException("OAuth token refresh can only be used with authorization");
         this.token = authenticator.refreshAccessToken().getToken();
+    }
+
+    @Override
+    public synchronized final void refreshOAuthToken(){
+        refreshToken();
     }
 
     //

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -64,15 +64,11 @@ final class MyAnimeListImpl extends MyAnimeList {
 
     private final MyAnimeListService service = MyAnimeListService.create();
 
-    MyAnimeListImpl(final String token){
-        this(token, true);
-    }
-
     MyAnimeListImpl(final String token_or_client, final boolean isToken){
         Objects.requireNonNull(token_or_client, (isToken ? "OAuth token" : "Client ID") + " can not be null");
         this.isTokenAuth = isToken;
         if(isToken){
-            if(!token.startsWith("Bearer "))
+            if(!token_or_client.startsWith("Bearer "))
                 throw new InvalidTokenException("OAuth token should start with 'Bearer'");
             this.token = token_or_client;
         }else

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListService.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListService.java
@@ -40,6 +40,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="anime")
     Response<JsonObject> getAnime(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Query("q")                                 final String search,
         @Query("limit")                             final Integer limit,
         @Query("offset")                            final Integer offset,
@@ -50,6 +51,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="anime/{anime_id}")
     Response<JsonObject> getAnime(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Path(value = "anime_id")                   final Long anime_id,
         @Query(value = "fields", encoded = true)    final String fields
     );
@@ -57,6 +59,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="anime/ranking")
     Response<JsonObject> getAnimeRanking(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Query("ranking_type")                      final String ranking_type,
         @Query("limit")                             final Integer limit,
         @Query("offset")                            final Integer offset,
@@ -67,6 +70,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="anime/season/{year}/{season}")
     Response<JsonObject> getAnimeSeason(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Path(value = "year")                       final Integer year,
         @Path(value = "season")                     final String season,
         @Query("sort")                              final String ranking_type,
@@ -129,12 +133,14 @@ interface MyAnimeListService {
 
     @Endpoint(method="GET", value="forum/boards")
     Response<JsonObject> getForumBoards(
-        @Header("Authorization") final String token
+        @Header("Authorization") final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id
     );
 
     @Endpoint(method="GET", value="forum/topic/{topic_id}")
     Response<JsonObject> getForumBoard(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Path(value = "topic_id")                   final Long topic_id,
         @Query("limit")                             final Integer limit,
         @Query("offset")                            final Integer offset
@@ -144,6 +150,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="forum/topics")
     Response<JsonObject> getForumTopics(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Query("board_id")                          final Long board_id,
         @Query("subboard_id")                       final Long subboard_id,
         @Query("limit")                             final Integer limit,
@@ -159,6 +166,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="manga")
     Response<JsonObject> getManga(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Query("q")                                 final String search,
         @Query("limit")                             final Integer limit,
         @Query("offset")                            final Integer offset,
@@ -169,6 +177,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="manga/{manga_id}")
     Response<JsonObject> getManga(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Path(value = "manga_id")                   final Long manga_id,
         @Query(value = "fields", encoded = true)    final String fields
     );
@@ -176,6 +185,7 @@ interface MyAnimeListService {
     @Endpoint(method="GET", value="manga/ranking")
     Response<JsonObject> getMangaRanking(
         @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
         @Query("ranking_type")                      final String ranking_type,
         @Query("limit")                             final Integer limit,
         @Query("offset")                            final Integer offset,

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListService.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListService.java
@@ -133,7 +133,7 @@ interface MyAnimeListService {
 
     @Endpoint(method="GET", value="forum/boards")
     Response<JsonObject> getForumBoards(
-        @Header("Authorization") final String token,
+        @Header("Authorization")                    final String token,
         @Header("X-MAL-CLIENT-ID")                  final String client_id
     );
 

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -34,6 +34,7 @@ public class TestAnimeListStatus {
     @AfterAll
     public static void afterAll(){
         if(mal == null) return;
+        TestProvider.requireToken();
 
         mal.deleteAnimeListing(TestProvider.AnimeID);
 

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -23,6 +23,7 @@ public class TestAnimeListStatus {
     @BeforeAll
     public static void beforeAll() throws IOException{
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
 
         final String file = "anime-list-" + System.currentTimeMillis() + ".txt";
         System.out.println("Running Anime list tests, saving backup of current list to '" + file + '\'');

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSuggestions.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnimeSuggestions.java
@@ -15,6 +15,7 @@ public class TestAnimeSuggestions {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestUserAnimeListing.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestUserAnimeListing.java
@@ -16,6 +16,7 @@ public class TestUserAnimeListing {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -33,6 +33,7 @@ public class TestMangaListStatus {
     @AfterAll
     public static void afterAll(){
         if(mal == null) return;
+        TestProvider.requireToken();
 
         mal.deleteMangaListing(TestProvider.MangaID);
 

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestMangaListStatus.java
@@ -23,6 +23,7 @@ public class TestMangaListStatus {
     @BeforeAll
     public static void beforeAll() throws IOException{
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
 
         final String file = "manga-list-" + System.currentTimeMillis() + ".txt";
         System.out.println("Running Manga list tests, saving backup of current list to '" + file + '\'');

--- a/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestUserMangaListing.java
+++ b/src/test/java/com/kttdevelopment/mal4j/MangaTests/TestUserMangaListing.java
@@ -16,6 +16,7 @@ public class TestUserMangaListing {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/TestAuthorizationLocalServer.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestAuthorizationLocalServer.java
@@ -22,7 +22,7 @@ public class TestAuthorizationLocalServer {
         // test refresh token
         Assertions.assertNotNull(mal.getAnime().withQuery(TestProvider.AnimeQuery).search(),
                                  Workflow.errorSupplier("Expected query to not be null"));
-        mal.refreshOAuthToken();
+        mal.refreshToken();
          Assertions.assertNotNull(mal.getAnime().withQuery(TestProvider.AnimeQuery).search(),
                                   Workflow.errorSupplier("Expected query to not be null"));
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestAuthorizationLocalServer.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestAuthorizationLocalServer.java
@@ -13,7 +13,7 @@ public class TestAuthorizationLocalServer {
 
     @BeforeAll // test token & refresh
     public static void beforeAll() throws IOException{
-        TestProvider.testRequireClientID();
+        TestProvider.requireHuman();
 
         final String clientId = TestProvider.readFile(TestProvider.client);
         authenticator = new MyAnimeListAuthenticator.LocalServerBuilder(clientId, 5050).openBrowser().build();
@@ -27,7 +27,7 @@ public class TestAuthorizationLocalServer {
                                   Workflow.errorSupplier("Expected query to not be null"));
 
         // write stable OAuth
-        Files.write(TestProvider.oauth.toPath(), authenticator.getAccessToken().getToken().getBytes(StandardCharsets.UTF_8));
+        Files.write(TestProvider.token.toPath(), authenticator.getAccessToken().getToken().getBytes(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -11,7 +11,7 @@ public class TestMyAnimeList {
 
     @BeforeAll
     public static void beforeAll(){
-        mal = MyAnimeList.withOAuthToken("Bearer null");
+        mal = MyAnimeList.withToken("Bearer null");
     }
 
     // auth parameter tests
@@ -24,19 +24,19 @@ public class TestMyAnimeList {
 
     @Test
     public void testNullToken(){
-        Assertions.assertThrows(NullPointerException.class, () -> MyAnimeList.withOAuthToken(null),
+        Assertions.assertThrows(NullPointerException.class, () -> MyAnimeList.withToken(null),
                                 Workflow.errorSupplier("Expected MyAnimeList#withOAuthToken with null token to throw a NullPointerException"));
     }
 
     @Test
     public void testNoBearerToken(){
-        Assertions.assertThrows(InvalidTokenException.class, () -> MyAnimeList.withOAuthToken("x"),
+        Assertions.assertThrows(InvalidTokenException.class, () -> MyAnimeList.withToken("x"),
                                 Workflow.errorSupplier("Expected MyAnimeList#withOAuthToken with invalid token to throw an IllegalArgumentException"));
     }
 
     @Test
     public void testInvalidToken(){
-        Assertions.assertThrows(InvalidTokenException.class, () -> MyAnimeList.withOAuthToken("Bearer invalid").getAnime(TestProvider.AnimeID),
+        Assertions.assertThrows(InvalidTokenException.class, () -> MyAnimeList.withToken("Bearer invalid").getAnime(TestProvider.AnimeID),
                                 Workflow.errorSupplier("Expected invalid token to throw InvalidTokenException"));
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestMyAnimeList.java
@@ -14,6 +14,14 @@ public class TestMyAnimeList {
         mal = MyAnimeList.withOAuthToken("Bearer null");
     }
 
+    // auth parameter tests
+
+    @Test
+    public void testNullClientID(){
+        Assertions.assertThrows(NullPointerException.class, () -> MyAnimeList.withClientID(null),
+                                Workflow.errorSupplier("Expected MyAnimeList#withClientID with null client ID to throw a NullPointerException"));
+    }
+
     @Test
     public void testNullToken(){
         Assertions.assertThrows(NullPointerException.class, () -> MyAnimeList.withOAuthToken(null),
@@ -37,6 +45,8 @@ public class TestMyAnimeList {
         Assertions.assertThrows(NullPointerException.class, () -> MyAnimeList.withAuthorization(null),
                                 Workflow.errorSupplier("Expected MyAnimeList#withAuthorizaton with null authenticator to throw a NullPointerException"));
     }
+
+    // null parameter tests
 
     @Test
     public void testNullAnimeRanking(){
@@ -73,6 +83,8 @@ public class TestMyAnimeList {
         Assertions.assertThrows(NullPointerException.class, () -> mal.getUser(null),
                                 Workflow.errorSupplier("Expected MyAnimeList#getUser of null user to throw a NullPointerException"));
     }
+
+    // inverted field test
 
     private static final String inverted = "^%s$|^%s(?=,)|(?<=\\w)\\{%s}|(?:^|,)%s\\{.*?}|,%s|(?<=\\{)%s,";
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -74,26 +74,24 @@ public abstract class TestProvider {
 
     @SuppressWarnings("GrazieInspection")
     public static void init() throws IOException{
-        if(hasClient || hasToken){ // if has client or token file
-            if(
+        if(
+            hasClient || hasToken && // if has client or token file
+            (
                 (hasClient && (!hasToken || !preferTokenAuth) && // if has client file or both but prefers client file
                 (mal = MyAnimeList.withClientID(strip(readFile(client)))) != null) // and client id was valid
                 || // OR
                 (hasToken && (!hasClient || preferTokenAuth) && // if has token file or both but prefers token file
                 (mal = MyAnimeList.withOAuthToken(strip(readFile(token)))) != null) // and token was valid
-            ){
-                isTokenAuth = hasClient && hasToken // if has both
-                            ? preferTokenAuth // use preferred
-                            : hasToken; // use token if exists, otherwise use client
-                return; // authenticated successfully
-            }
-
-            requireHuman(); // prevent CI from trying to authenticate
-            TestAuthorizationLocalServer.beforeAll(); // create token
+            )
+        ){
+            isTokenAuth = hasClient && hasToken // if has both
+                        ? preferTokenAuth // use preferred
+                        : hasToken; // use token if exists, otherwise use client
             return; // authenticated successfully
         }
-        // failed to authenticate
-        Assertions.fail(Workflow.errorSupplier("Failed to authenticate with MyAnimeList, client or token file is missing or the value is invalid"));
+
+        requireHuman(); // prevent CI from trying to authenticate
+        TestAuthorizationLocalServer.beforeAll(); // create token
     }
 
     public static void requireHuman(){ // skip test on CI

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -81,7 +81,7 @@ public abstract class TestProvider {
                 (mal = MyAnimeList.withClientID(strip(readFile(client)))) != null) // and client id was valid
                 || // OR
                 (hasToken && (!hasClient || preferTokenAuth) && // if has token file or both but prefers token file
-                (mal = MyAnimeList.withOAuthToken(strip(readFile(token)))) != null) // and token was valid
+                (mal = MyAnimeList.withToken(strip(readFile(token)))) != null) // and token was valid
             )
         ){
             isTokenAuth = hasClient && hasToken // if has both

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -1,11 +1,11 @@
 package com.kttdevelopment.mal4j;
 
+import dev.katsute.jcore.Workflow;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.provider.Arguments;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -50,11 +50,17 @@ public abstract class TestProvider {
     //
 
     private static MyAnimeList mal;
+    private static boolean isTokenAuth = false;
 
-    //
+    public static void requireToken(){
+        Assumptions.assumeTrue(isTokenAuth, "Test requires a token");
+    }
 
     static final File client = new File("src/test/java/resources/client.txt");
-    static final File oauth  = new File("src/test/java/resources/oauth.txt");
+    static final File token  = new File("src/test/java/resources/token.txt");
+
+    private static final boolean hasClient = client.exists();
+    private static final boolean hasToken  = token.exists();
 
     static {
         APICall.debug = false;
@@ -63,15 +69,35 @@ public abstract class TestProvider {
             System.out.println("\u001b[41;1m" + "\n                    WARNING: DEBUG MODE IS ON\n\n" + "\u001b[0m");
     }
 
+    // this value should be TRUE if you are committing this file
+    private static final boolean preferTokenAuth = true; // preferred auth when both files exist
+
+    @SuppressWarnings("GrazieInspection")
     public static void init() throws IOException{
-        if(oauth.exists() && (mal = MyAnimeList.withOAuthToken(strip(readFile(oauth)))).getAnime(AnimeID, Fields.NO_FIELDS) != null)
-            return; // skip if oauth exists and is usable
-        testRequireClientID(); // prevent CI from trying to authenticate
-        TestAuthorizationLocalServer.beforeAll(); // refresh old token
+        if(hasClient || hasToken){ // if has client or token file
+            if(
+                (hasClient && (!hasToken || !preferTokenAuth) && // if has client file or both but prefers client file
+                (mal = MyAnimeList.withClientID(strip(readFile(client)))) != null) // and client id was valid
+                || // OR
+                (hasToken && (!hasClient || preferTokenAuth) && // if has token file or both but prefers token file
+                (mal = MyAnimeList.withOAuthToken(strip(readFile(token)))) != null) // and token was valid
+            ){
+                isTokenAuth = hasClient && hasToken // if has both
+                            ? preferTokenAuth // use preferred
+                            : hasToken; // use token if exists, otherwise use client
+                return; // authenticated successfully
+            }
+
+            requireHuman(); // prevent CI from trying to authenticate
+            TestAuthorizationLocalServer.beforeAll(); // create token
+            return; // authenticated successfully
+        }
+        // failed to authenticate
+        Assertions.fail(Workflow.errorSupplier("Failed to authenticate with MyAnimeList, client or token file is missing or the value is invalid"));
     }
 
-    public static void testRequireClientID(){
-        Assumptions.assumeTrue(client.exists(), "File with Client ID was missing, please create a file with the Client ID at: " + client.getAbsolutePath());
+    public static void requireHuman(){ // skip test on CI
+        Assumptions.assumeFalse("true".equals(System.getenv("CI")), "Test requires a human, CI testing not supported");
     }
 
     public static MyAnimeList getMyAnimeList(){
@@ -79,8 +105,10 @@ public abstract class TestProvider {
             init();
             return mal;
         }catch(final IOException e){
-            e.printStackTrace();
-            Assertions.fail();
+            final StringWriter sw = new StringWriter();
+            final PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            Assertions.fail(Workflow.errorSupplier(sw.toString()));
             return null;
         }
     }

--- a/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestProvider.java
@@ -75,7 +75,7 @@ public abstract class TestProvider {
     @SuppressWarnings("GrazieInspection")
     public static void init() throws IOException{
         if(
-            hasClient || hasToken && // if has client or token file
+            (hasClient || hasToken) && // if has client or token file
             (
                 (hasClient && (!hasToken || !preferTokenAuth) && // if has client file or both but prefers client file
                 (mal = MyAnimeList.withClientID(strip(readFile(client)))) != null) // and client id was valid

--- a/src/test/java/com/kttdevelopment/mal4j/TestREADME.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestREADME.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class TestREADME {
 
     public void testSearchQueries(){
-        MyAnimeList mal = MyAnimeList.withOAuthToken("");
+        MyAnimeList mal = MyAnimeList.withToken("");
         List<AnimePreview> search =
             mal.getAnime()
                 .withQuery("さくら荘のペットな彼女")
@@ -27,7 +27,7 @@ public class TestREADME {
     }
 
     public void testListModification(){
-        MyAnimeList mal = MyAnimeList.withOAuthToken("");
+        MyAnimeList mal = MyAnimeList.withToken("");
         MangaListStatus status =
             mal.updateMangaListing(28107)
                 .status(MangaStatus.Reading)
@@ -43,7 +43,7 @@ public class TestREADME {
     }
 
     public void testStructuredObjects(){
-        MyAnimeList mal = MyAnimeList.withOAuthToken("");
+        MyAnimeList mal = MyAnimeList.withToken("");
         Anime anime = mal.getAnime(13759);
 
         String ja = anime.getAlternativeTitles().getJapanese();
@@ -55,11 +55,15 @@ public class TestREADME {
 
     // setup
 
-    public void testAdvancedOAuth(){
-        MyAnimeList mal = MyAnimeList.withOAuthToken("oauth_token");
+    public void testClient(){
+        MyAnimeList mal = MyAnimeList.withClientID("client_id");
     }
 
-    public void testClientAuth(){
+    public void testToken(){
+        MyAnimeList mal = MyAnimeList.withToken("Bearer oauth_token");
+    }
+
+    public void testOAuth2(){
         String authorization_url = MyAnimeListAuthenticator.getAuthorizationURL("client_id", "PKCE_code_challenge");
 
         MyAnimeList mal = MyAnimeList.withAuthorization(new MyAnimeListAuthenticator("client_id", "client_secret", "authorization_code", "PKCE_code_challenge"));

--- a/src/test/java/com/kttdevelopment/mal4j/TestREADME.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestREADME.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class TestREADME {
 
     public void testSearchQueries(){
-        MyAnimeList mal = MyAnimeList.withToken("");
+        MyAnimeList mal = MyAnimeList.withClientID("");
         List<AnimePreview> search =
             mal.getAnime()
                 .withQuery("さくら荘のペットな彼女")
@@ -43,7 +43,7 @@ public class TestREADME {
     }
 
     public void testStructuredObjects(){
-        MyAnimeList mal = MyAnimeList.withToken("");
+        MyAnimeList mal = MyAnimeList.withClientID("");
         Anime anime = mal.getAnime(13759);
 
         String ja = anime.getAlternativeTitles().getJapanese();

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -26,6 +26,7 @@ public class TestUser {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+        TestProvider.requireToken();
         user = mal.getAuthenticatedUser(Fields.user);
     }
 


### PR DESCRIPTION
### Prerequisites
*If checks are not passed then the pull request will be closed.*

 - [x] I have checked that no other similar pull request already exists.
 - [x] My code follows the general code style as the rest of the code.
 - [x] I have checked that no sensitive information is exposed.
 - [x] Build compiles.
 - [x] Build passes test cases.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Workflow Run

https://github.com/Katsute/Mal4J/actions/runs/1478373853

### Changes Made
*List any changes made and/or other relevant issues.*

 - Add ability to authenticate with client ID only #256
 - Throw exception on write operations when there is no token
 - Change `MyAnimeList.withOAuthToken(String)` to `MyAnimeList.withToken(String)`
 - [DEPRECATED] Deprecate `MyAnimeList.withOAuthToken(String)`
 - Change `MyAnimeList.refreshOAuthToken()` to `MyAnimeList.refreshToken()`
 - [DEPRECATED] Deprecate `MyAnimeList.refreshOAuthToken()`
 - [TESTS] Update test matrix to run client and token tests
 - [TESTS] Update MAL test provider
 - [TESTS] SKIP write/private tests on client tests
 - [TESTS] ADD tests for client ID
 - [DOCS] Documentation ordering tweaks
 - [DOCS] Update setup guide
 - [DOCS] Update FAQ
 - [DOCS] Update README